### PR TITLE
Added a LiquidCrystal library to stdlib

### DIFF
--- a/src/stdlib/Makefile
+++ b/src/stdlib/Makefile
@@ -4,7 +4,7 @@ MODULES :=                                                       \
   std_exit pervasives char bytes bytesLabels string stringLabels \
   list listLabels map array arrayLabels uchar sys buffer random  \
   complex gc int32 int64 obj hashtbl set moreLabels queue sort   \
-  stack stdLabels avr
+  stack stdLabels avr liquidCrystal
 
 MLS  := $(MODULES:=.ml)
 MLIS := $(MODULES:=.mli)

--- a/src/stdlib/liquidCrystal.ml
+++ b/src/stdlib/liquidCrystal.ml
@@ -1,0 +1,233 @@
+(*******************************************************************************)
+(*                                                                             *)
+(*            Port of the LiquidCrystal library in OCaml (for OMicroB)         *)
+(*       Original lib : https://github.com/arduino-libraries/LiquidCrystal     *)
+(*                                                                             *)
+(*                    Basile Pesin, Sorbonne Université                        *)
+(*******************************************************************************)
+
+open Avr
+
+(* Commands *)
+let lcd_cleardisplay = 0x01
+and lcd_returnhome = 0x02
+and lcd_entrymodeset = 0x04
+and lcd_displaycontrol = 0x08
+and lcd_cursorshift = 0x10
+and lcd_functionset = 0x20
+and lcd_setcgramaddr = 0x40
+and lcd_setddramaddr = 0x80
+
+(* Flags for display on / off control *)
+let lcd_displayon = 0x04
+(* and lcd_displayoff = 0x00 *)
+and lcd_cursoron = 0x02
+and lcd_cursoroff = 0x00
+and lcd_blinkon = 0x01
+and lcd_blinkoff = 0x00
+
+(* Flags for entry mode *)
+let (* lcd_entryright = 0x00
+ * and *) lcd_entryleft = 0x02
+and lcd_entryshiftincrement = 0x01
+and lcd_entryshiftdecrement = 0x00
+
+(* Flags for display/cursor move *)
+let lcd_displaymove = 0x08
+(* and lcd_cursormove = 0x00 *)
+and lcd_moveright = 0x04
+and lcd_moveleft = 0x00
+
+(* Flags for function set *)
+let lcd_8bitmode = 0x10 and lcd_4bitmode = 0x00
+and lcd_2line = 0x08 and lcd_1line = 0x00
+(* and lcd_5x10dots = 0x04 *) and lcd_5x8dots = 0x00;
+
+type ('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i) lcd = {
+  is4bitmode : bool;
+  rsPin : ('a register, 'b register, 'c register) pin;
+  enablePin : ('d register, 'e register, 'f register) pin;
+  dpins : ('g register, 'h register, 'i register) pin array;
+  mutable displayFunction : int;
+  mutable displayMode : int;
+  mutable displayControl : int;
+  mutable numLines : int;
+  mutable rowOffsets : int array;
+}
+
+(********************** Low level data pushing commands ************************)
+
+let pulseEnable lcd =
+  digital_write lcd.enablePin LOW;
+  delay 1;
+  digital_write lcd.enablePin HIGH;
+  delay 1;
+  digital_write lcd.enablePin LOW;
+  delay 1
+
+let write4bits lcd value =
+  for i = 0 to 3 do
+    digital_write lcd.dpins.(i) (if ((value lsr i) land 0x01)> 0 then HIGH else LOW)
+  done;
+
+  pulseEnable lcd
+
+let write8bits lcd value =
+  for i = 0 to 7 do
+    digital_write lcd.dpins.(i) (if ((value lsr i) land 0x01) > 0 then HIGH else LOW)
+  done;
+
+  pulseEnable lcd
+
+let send lcd value mode =
+  digital_write lcd.rsPin mode;
+
+  if not lcd.is4bitmode then write8bits lcd value
+  else begin
+    write4bits lcd (value lsr 4);
+    write4bits lcd value
+  end
+
+(**************** Mid level commands, for sending data / cmds ******************)
+
+let command lcd value = send lcd value LOW
+
+let write lcd value = send lcd value HIGH
+
+(************************** High level user commands ***************************)
+
+let clear lcd = command lcd lcd_cleardisplay; delay 2
+
+let noDisplay lcd =
+  lcd.displayControl <- lcd.displayControl land (lnot lcd_displayon);
+  command lcd (lcd_displaycontrol lor lcd.displayControl)
+
+let display lcd =
+  lcd.displayControl <- lcd.displayControl lor lcd_displayon;
+  command lcd (lcd_displaycontrol lor lcd.displayControl)
+
+let noCursor lcd =
+  lcd.displayControl <- lcd.displayControl land (lnot lcd_cursoron);
+  command lcd (lcd_displaycontrol lor lcd.displayControl)
+
+let cursor lcd =
+  lcd.displayControl <- lcd.displayControl lor lcd_cursoron;
+  command lcd (lcd_displaycontrol lor lcd.displayControl)
+
+let noBlink lcd =
+  lcd.displayControl <- lcd.displayControl land (lnot lcd_blinkon);
+  command lcd (lcd_displaycontrol lor lcd.displayControl)
+
+let blink lcd =
+  lcd.displayControl <- lcd.displayControl lor lcd_blinkon;
+  command lcd (lcd_displaycontrol lor lcd.displayControl)
+
+let leftToRight lcd =
+  lcd.displayMode <- lcd.displayMode lor lcd_entryleft;
+  command lcd (lcd_entrymodeset lor lcd.displayMode)
+
+let rightToLeft lcd =
+  lcd.displayMode <- lcd.displayMode land (lnot lcd_entryleft);
+  command lcd (lcd_entrymodeset lor lcd.displayMode)
+
+let autoscroll lcd =
+  lcd.displayMode <- lcd.displayMode lor lcd_entryshiftincrement;
+  command lcd (lcd_entrymodeset lor lcd.displayMode)
+
+let noAutoscroll lcd =
+  lcd.displayMode <- lcd.displayMode land (lnot lcd_entryshiftincrement);
+  command lcd (lcd_entrymodeset lor lcd.displayMode)
+
+let setRowOffsets lcd r0 r1 r2 r3 = lcd.rowOffsets <- [|r0;r1;r2;r3|]
+
+let lcdBegin lcd c l =
+  if l > 1 then lcd.displayFunction <- lcd.displayFunction lor lcd_2line;
+  lcd.numLines <- l;
+
+  setRowOffsets lcd 0x00 0x40 (0x00 + c) (0x40 + c);
+
+  (* Set output mode for the pins *)
+  pin_mode lcd.rsPin OUTPUT;
+  pin_mode lcd.enablePin OUTPUT;
+  Array.iter (fun p -> pin_mode p OUTPUT) lcd.dpins;
+
+  delay 50;
+
+  digital_write lcd.rsPin LOW;
+  digital_write lcd.enablePin LOW;
+
+  if (lcd.displayFunction land lcd_8bitmode) = 0 then begin
+    write4bits lcd 0x03;
+    delay 5;
+    write4bits lcd 0x03;
+    delay 5;
+    write4bits lcd 0x03;
+    delay 1;
+    write4bits lcd 0x02;
+  end
+  else begin
+    command lcd (lcd_functionset lor lcd.displayFunction);
+    delay 5;
+    command lcd (lcd_functionset lor lcd.displayFunction);
+    delay 1;
+    command lcd (lcd_functionset lor lcd.displayFunction);
+  end;
+
+  command lcd (lcd_functionset lor lcd.displayFunction);
+
+  (* Turn the display on *)
+  lcd.displayControl <- lcd_displayon lor lcd_cursoroff lor lcd_blinkoff;
+  display lcd;
+
+  (* Clear the display *)
+  clear lcd;
+
+  (* Set entry mode *)
+  lcd.displayMode <- lcd_entryleft lor lcd_entryshiftdecrement;
+  command lcd (lcd_entrymodeset lor lcd.displayMode)
+
+let create4bitmode rs enable d0 d1 d2 d3 = let lcd = {
+    is4bitmode = true;
+    rsPin = rs;
+    enablePin = enable;
+    dpins = [|d0;d1;d2;d3|];
+    displayFunction = lcd_4bitmode lor lcd_1line lor lcd_5x8dots;
+    displayMode = 0;
+    displayControl = 0;
+    numLines = 0;
+    rowOffsets = [||];
+  } in lcdBegin lcd 16 1; lcd
+
+let create8bitmode rs enable d0 d1 d2 d3 d4 d5 d6 d7 =
+  let lcd = {
+    is4bitmode = false;
+    rsPin = rs;
+    enablePin = enable;
+    dpins = [|d0;d1;d2;d3;d4;d5;d6;d7|];
+    displayFunction =lcd_8bitmode lor lcd_1line lor lcd_5x8dots;
+    displayMode = 0;
+    displayControl = 0;
+    numLines = 0;
+    rowOffsets = [||];
+  } in lcdBegin lcd 16 1; lcd
+
+let print lcd s =
+  String.iter (fun c -> write lcd (int_of_char c)) s
+
+let scrollDisplayLeft lcd =
+  command lcd (lcd_cursorshift lor lcd_displaymove lor lcd_moveleft)
+
+let scrollDisplayRight lcd =
+  command lcd (lcd_cursorshift lor lcd_displaymove lor lcd_moveright)
+
+let setCursor lcd c r =
+  command lcd (lcd_setddramaddr lor (c + lcd.rowOffsets.(r)))
+
+let home lcd =
+  command lcd lcd_returnhome;
+  delay 2
+
+let createChar lcd loc data =
+  let location = loc land 0x7 in
+  command lcd (lcd_setcgramaddr lor (location lsl 3));
+  Array.iter (fun c -> write lcd c) data;

--- a/src/stdlib/liquidCrystal.mli
+++ b/src/stdlib/liquidCrystal.mli
@@ -1,0 +1,85 @@
+(*******************************************************************************)
+(*                                                                             *)
+(*            Port of the LiquidCrystal library in OCaml (for OMicroB)         *)
+(*       Original lib : https://github.com/arduino-libraries/LiquidCrystal     *)
+(*                                                                             *)
+(*                    Basile Pesin, Sorbonne Université                        *)
+(*            see : https://www.arduino.cc/en/Reference/LiquidCrystal          *)
+(*******************************************************************************)
+
+open Avr
+
+type ('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i) lcd
+
+(** Initialise a LCD in 4-bit mode : [create_4bitmode rs enable d0 d1 d2 d3] *)
+val create4bitmode : ('a register, 'b register, 'c register) pin ->
+  ('d register, 'e register, 'f register) pin ->
+  ('g register, 'h register, 'i register) pin -> ('g register, 'h register, 'i register) pin ->
+  ('g register, 'h register, 'i register) pin -> ('g register, 'h register, 'i register) pin ->
+  ('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i) lcd
+
+(** Initialise a LCD in 8-bit mode : [create_8bitmode rs enable d0 d1 d2 d3 d4 d5 d6 d7] *)
+val create8bitmode :  ('a register, 'b register, 'c register) pin ->
+  ('d register, 'e register, 'f register) pin ->
+  ('g register, 'h register, 'i register) pin -> ('g register, 'h register, 'i register) pin ->
+  ('g register, 'h register, 'i register) pin -> ('g register, 'h register, 'i register) pin ->
+  ('g register, 'h register, 'i register) pin -> ('g register, 'h register, 'i register) pin ->
+  ('g register, 'h register, 'i register) pin -> ('g register, 'h register, 'i register) pin ->
+  ('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i) lcd
+
+(** Start the LCD display with c columns and l lines : [lcdBegin lcd c l]. Was named [begin] in the C library, but is renamed because begin is a keyword in OCaml *)
+val lcdBegin : _ lcd -> int -> int -> unit
+
+(** Clear the LCD display *)
+val clear : _ lcd -> unit
+
+(** Set the cursor to home position *)
+val home : _ lcd -> unit
+
+(** Turn off the LCD display, without loosing it's text *)
+val noDisplay : _ lcd -> unit
+
+(** Turn on the LCD display *)
+val display : _ lcd -> unit
+
+(** Turn off the blinking cursor *)
+val noBlink : _ lcd -> unit
+
+(** Turn on the blinking cursor *)
+val blink : _ lcd -> unit
+
+(** Turn off the cursor *)
+val noCursor : _ lcd -> unit
+
+(** Turn on the cursor *)
+val cursor : _ lcd -> unit
+
+(** Scroll the content (text and cursor) of display one space to the left *)
+val scrollDisplayLeft : _ lcd -> unit
+
+(** Scroll the content (text and cursor) of display one space to the right *)
+val scrollDisplayRight : _ lcd -> unit
+
+(** Write from left to right (default) *)
+val leftToRight : _ lcd -> unit
+
+(** Write from right to left *)
+val rightToLeft : _ lcd -> unit
+
+(** Turn on autoscroll *)
+val autoscroll : _ lcd -> unit
+
+(** Turn off autoscroll *)
+val noAutoscroll : _ lcd -> unit
+
+(** Set the cursor to column c and row r : [setCursor lcd c r]*)
+val setCursor : _ lcd -> int -> int -> unit
+
+(** Write a character to the LCD display *)
+val write : _ lcd -> int -> unit
+
+(** Print text to the LCD display *)
+val print : _ lcd -> string -> unit
+
+(** Create a special character in one of the 8 CGRAM locations : [createChar lcd loc data] where loc is a number between 0 and 7, and data is an int array of size 7. Use before begin ! *)
+val createChar : _ lcd -> int -> int array -> unit

--- a/tests/tuto_7_liquidcrystal/.gitignore
+++ b/tests/tuto_7_liquidcrystal/.gitignore
@@ -1,0 +1,1 @@
+lcdexample.c

--- a/tests/tuto_7_liquidcrystal/Makefile
+++ b/tests/tuto_7_liquidcrystal/Makefile
@@ -1,0 +1,22 @@
+include ../../etc/Makefile.conf
+
+SOURCES := lcdexample.ml
+TARGETS := lcdexample.byte lcdexample.c lcdexample.elf lcdexample.avr lcdexample.hex
+
+all: $(TARGETS)
+
+$(TARGETS): $(SOURCES)
+	$(BIN)/omicrob -v $^ -heap-size 256
+
+flash: lcdexample.hex
+	$(BIN)/omicrob -flash -sudo $<
+
+simul: lcdexample.elf
+	./$<
+
+clean:
+	@rm -f *.cmo *.cmi
+	@rm -rf *.elf.dSYM
+	@rm -f $(TARGETS)
+
+.PHONY: all flash clean

--- a/tests/tuto_7_liquidcrystal/lcdexample.ml
+++ b/tests/tuto_7_liquidcrystal/lcdexample.ml
@@ -1,0 +1,26 @@
+open Avr
+open LiquidCrystal
+
+let () =
+  let lcd = create4bitmode PIN12 PIN11 PIN5 PIN4 PIN3 PIN2 in
+
+  (* The function int_of_string is not available in OMicroB, so we'll convert binary to decimal ourselves ! *)
+  let smiley =[| (* 00000 *) 0;
+                 (* 10001 *) 17;
+                 (* 00000 *) 0;
+                 (* 00000 *) 0;
+                 (* 10001 *) 17;
+                 (* 01110 *) 14;
+                 (* 00000 *) 0|] in
+  createChar lcd 0 smiley;
+
+  lcdBegin lcd 16 2;
+
+  setCursor lcd 2 0;
+  print lcd "Hello world!";
+
+  setCursor lcd 0 1;
+  write lcd 0;
+
+  setCursor lcd 15 1;
+  write lcd 0;


### PR DESCRIPTION
Implemented the [LiquidCrystal](https://github.com/arduino-libraries/LiquidCrystal) library in OCaml.
This library (described [here](https://www.arduino.cc/en/Reference/LiquidCrystal)) can be used with LCd screens based on the Hitachi HD44780 chipset.
The library is implemented in the module LiquidCrystal, which I added to the stdlib. The function names are the same as in OMicroB, except for `begin` which becomes `lcdBegin`, and for the constructor `LiquidCrystal` which becomes either `create4bitmode` or `create8bitmode`.
All functions take an object of type `lcd` as a parameter (rather than using a lcd class), followed by the same parameters as in the C library.
I also added an exemple (tuto_7_liquidcrystal) which shows the basis of how to write on the screen.