### PR TITLE
Proposal: Simplify pin gadt

### DIFF
--- a/avrs/arduboy/avr.ml
+++ b/avrs/arduboy/avr.ml
@@ -1,41 +1,29 @@
-type portb_bit = PB0 | PB1 | PB2 | PB3 | PB4 | PB5 | PB6 | PB7
-type portc_bit = PC0 | PC1 | PC2 | PC3 | PC4 | PC5 | PC6 | PC7
-type portd_bit = PD0 | PD1 | PD2 | PD3 | PD4 | PD5 | PD6 | PD7
-type porte_bit = PE0 | PE1 | PE2 | PE3 | PE4 | PE5 | PE6 | PE7
-type portf_bit = PF0 | PF1 | PF2 | PF3 | PF4 | PF5 | PF6 | PF7
-
-type ddrb_bit = DB0 | DB1 | DB2 | DB3 | DB4 | DB5 | DB6 | DB7
-type ddrc_bit = DC0 | DC1 | DC2 | DC3 | DC4 | DC5 | DC6 | DC7
-type ddrd_bit = DD0 | DD1 | DD2 | DD3 | DD4 | DD5 | DD6 | DD7
-type ddre_bit = DE0 | DE1 | DE2 | DE3 | DE4 | DE5 | DE6 | DE7
-type ddrf_bit = DF0 | DF1 | DF2 | DF3 | DF4 | DF5 | DF6 | DF7
-
-type pinb_bit = IB0 | IB1 | IB2 | IB3 | IB4 | IB5 | IB6 | IB7
-type pinc_bit = IC0 | IC1 | IC2 | IC3 | IC4 | IC5 | IC6 | IC7
-type pind_bit = ID0 | ID1 | ID2 | ID3 | ID4 | ID5 | ID6 | ID7
-type pine_bit = IE0 | IE1 | IE2 | IE3 | IE4 | IE5 | IE6 | IE7
-type pinf_bit = IF0 | IF1 | IF2 | IF3 | IF4 | IF5 | IF6 | IF7
+type b_bit = B0 | B1 | B2 | B3 | B4 | B5 | B6 | B7
+type c_bit = C0 | C1 | C2 | C3 | C4 | C5 | C6 | C7
+type d_bit = D0 | D1 | D2 | D3 | D4 | D5 | D6 | D7
+type e_bit = E0 | E1 | E2 | E3 | E4 | E5 | E6 | E7
+type f_bit = F0 | F1 | F2 | F3 | F4 | F5 | F6 | F7
 
 type spcr_bit = SPR0 | SPR1 | CPHA | CPOL | MSTR | DORD | SPE | SPIE
 type spsr_bit = SPI2x | SPSR1 | SPSR2 | SPSR3 | SPSR4 | SPSR5 | SPSR6 | SPIF
 type spdr_bit = SPDR0 | SPDR1 | SPDR2 | SPDR3 | SPDR4 | SPDR5 | SPDR6 | SPDR7
 
 type 'a register =
-  | PORTB : portb_bit register
-  | PORTC : portc_bit register
-  | PORTD : portd_bit register
-  | PORTE : porte_bit register
-  | PORTF : portf_bit register
-  | DDRB : ddrb_bit register
-  | DDRC : ddrc_bit register
-  | DDRD : ddrd_bit register
-  | DDRE : ddre_bit register
-  | DDRF : ddrf_bit register
-  | PINB : pinb_bit register
-  | PINC : pinc_bit register
-  | PIND : pind_bit register
-  | PINE : pine_bit register
-  | PINF : pinf_bit register
+  | PORTB : b_bit register
+  | PORTC : c_bit register
+  | PORTD : d_bit register
+  | PORTE : e_bit register
+  | PORTF : f_bit register
+  | DDRB : b_bit register
+  | DDRC : c_bit register
+  | DDRD : d_bit register
+  | DDRE : e_bit register
+  | DDRF : f_bit register
+  | PINB : b_bit register
+  | PINC : c_bit register
+  | PIND : d_bit register
+  | PINE : e_bit register
+  | PINF : f_bit register
   | SPCR : spcr_bit register
   | SPSR : spsr_bit register
   | SPDR : spsr_bit register
@@ -47,37 +35,41 @@ type 'a analog_pin =
   | YES : yes analog_pin
   | NO : no analog_pin
 
-type ('a,'b,'c,'d) pin =
-  | PIN0  : (portd_bit register, ddrd_bit register, pind_bit register, no analog_pin) pin
-  | PIN1  : (portd_bit register, ddrd_bit register, pind_bit register, no analog_pin) pin
-  | PIN2  : (portd_bit register, ddrd_bit register, pind_bit register, no analog_pin) pin
-  | PIN3  : (portd_bit register, ddrd_bit register, pind_bit register, no analog_pin) pin
-  | PIN4  : (portd_bit register, ddrd_bit register, pind_bit register, no analog_pin) pin
-  | PIN5  : (portc_bit register, ddrc_bit register, pinc_bit register, no analog_pin) pin
-  | PIN6  : (portd_bit register, ddrd_bit register, pind_bit register, no analog_pin) pin
-  | PIN7  : (porte_bit register, ddre_bit register, pine_bit register, no analog_pin) pin
-  | PIN8  : (portb_bit register, ddrb_bit register, pinb_bit register, no analog_pin) pin
-  | PIN9  : (portb_bit register, ddrb_bit register, pinb_bit register, no analog_pin) pin
-  | PIN10 : (portb_bit register, ddrb_bit register, pinb_bit register, no analog_pin) pin
-  | PIN11 : (portb_bit register, ddrb_bit register, pinb_bit register, no analog_pin) pin
-  | PIN12 : (portd_bit register, ddrd_bit register, pind_bit register, no analog_pin) pin
-  | PIN13 : (portc_bit register, ddrc_bit register, pinc_bit register, no analog_pin) pin
-  | MISO  : (portb_bit register, ddrb_bit register, pinb_bit register, no analog_pin) pin
-  | SCK   : (portb_bit register, ddrb_bit register, pinb_bit register, no analog_pin) pin
-  | MOSI  : (portb_bit register, ddrb_bit register, pinb_bit register, no analog_pin) pin
-  | SS    : (portb_bit register, ddrb_bit register, pinb_bit register, no analog_pin) pin
-  | PINA0 : (portf_bit register, ddrf_bit register, pinf_bit register, no analog_pin) pin
-  | PINA1 : (portf_bit register, ddrf_bit register, pinf_bit register, no analog_pin) pin
-  | PINA2 : (portf_bit register, ddrf_bit register, pinf_bit register, no analog_pin) pin
-  | PINA3 : (portf_bit register, ddrf_bit register, pinf_bit register, no analog_pin) pin
-  | PINA4 : (portf_bit register, ddrf_bit register, pinf_bit register, no analog_pin) pin
-  | PINA5 : (portf_bit register, ddrf_bit register, pinf_bit register, no analog_pin) pin
+type 'a pwm_pin =
+  | YES : yes pwm_pin
+  | NO : no pwm_pin
+
+type ('a,'b,'c) pin =
+  | PIN0  : (d_bit register, no analog_pin, no pwm_pin) pin
+  | PIN1  : (d_bit register, no analog_pin, no pwm_pin) pin
+  | PIN2  : (d_bit register, no analog_pin, no pwm_pin) pin
+  | PIN3  : (d_bit register, no analog_pin, no pwm_pin) pin
+  | PIN4  : (d_bit register, no analog_pin, no pwm_pin) pin
+  | PIN5  : (c_bit register, no analog_pin, no pwm_pin) pin
+  | PIN6  : (d_bit register, no analog_pin, no pwm_pin) pin
+  | PIN7  : (e_bit register, no analog_pin, no pwm_pin) pin
+  | PIN8  : (b_bit register, no analog_pin, no pwm_pin) pin
+  | PIN9  : (b_bit register, no analog_pin, no pwm_pin) pin
+  | PIN10 : (b_bit register, no analog_pin, no pwm_pin) pin
+  | PIN11 : (b_bit register, no analog_pin, no pwm_pin) pin
+  | PIN12 : (d_bit register, no analog_pin, no pwm_pin) pin
+  | PIN13 : (c_bit register, no analog_pin, no pwm_pin) pin
+  | MISO  : (b_bit register, no analog_pin, no pwm_pin) pin
+  | SCK   : (b_bit register, no analog_pin, no pwm_pin) pin
+  | MOSI  : (b_bit register, no analog_pin, no pwm_pin) pin
+  | SS    : (b_bit register, no analog_pin, no pwm_pin) pin
+  | PINA0 : (f_bit register, no analog_pin, no pwm_pin) pin
+  | PINA1 : (f_bit register, no analog_pin, no pwm_pin) pin
+  | PINA2 : (f_bit register, no analog_pin, no pwm_pin) pin
+  | PINA3 : (f_bit register, no analog_pin, no pwm_pin) pin
+  | PINA4 : (f_bit register, no analog_pin, no pwm_pin) pin
+  | PINA5 : (f_bit register, no analog_pin, no pwm_pin) pin
 
 type mode = INPUT | OUTPUT | INPUT_PULLUP
 
 type level = LOW | HIGH
 
-let port_of_pin : type a b c d. (a register,b register, c register, d analog_pin) pin -> a register =
+let port_of_pin : type a b c. (a register, b analog_pin, c pwm_pin) pin -> a register =
   function
   | PIN0 -> PORTD
   | PIN1 -> PORTD
@@ -104,7 +96,7 @@ let port_of_pin : type a b c d. (a register,b register, c register, d analog_pin
   | PINA4 -> PORTF
   | PINA5 -> PORTF
 
-let ddr_of_pin : type a b c d. (a register , b register, c register, d analog_pin) pin -> b register=
+let ddr_of_pin : type a b c. (a register , b analog_pin, c pwm_pin) pin -> a register=
   function
   | PIN0 -> DDRD
   | PIN1 -> DDRD
@@ -132,7 +124,7 @@ let ddr_of_pin : type a b c d. (a register , b register, c register, d analog_pi
   | PINA5 -> DDRF
 
 
-let input_of_pin : type a b c d. (a register , b register, c register, d analog_pin) pin -> c register=
+let input_of_pin : type a b c. (a register , b analog_pin, c pwm_pin) pin -> a register=
   function
   | PIN0 -> PIND
   | PIN1 -> PIND
@@ -159,89 +151,32 @@ let input_of_pin : type a b c d. (a register , b register, c register, d analog_
   | PINA4 -> PINF
   | PINA5 -> PINF
 
-let port_bit_of_pin : type a b c d. (a register, b register, c register, d analog_pin) pin -> a =
+let bit_of_pin : type a b c. (a register, b analog_pin, c pwm_pin) pin -> a =
   function
-  | PIN0 -> PD2
-  | PIN1 -> PD3
-  | PIN2 -> PD1
-  | PIN3 -> PD0
-  | PIN4 -> PD4
-  | PIN5 -> PC6
-  | PIN6 -> PD7
-  | PIN7 -> PE6
-  | PIN8 -> PB4
-  | PIN9 -> PB5
-  | PIN10 -> PB6
-  | PIN11 -> PB7
-  | PIN12 -> PD6
-  | PIN13 -> PC7
-  | MISO -> PB3
-  | SCK -> PB1
-  | MOSI -> PB2
-  | SS -> PB0
-  | PINA0 -> PF7
-  | PINA1 -> PF6
-  | PINA2 -> PF5
-  | PINA3 -> PF4
-  | PINA4 -> PF1
-  | PINA5 -> PF0
-
-
-let ddr_bit_of_pin : type a b c d. (a register, b register, c register, d analog_pin) pin -> b =
-  function
-  | PIN0 -> DD2
-  | PIN1 -> DD3
-  | PIN2 -> DD1
-  | PIN3 -> DD0
-  | PIN4 -> DD4
-  | PIN5 -> DC6
-  | PIN6 -> DD7
-  | PIN7 -> DE6
-  | PIN8 -> DB4
-  | PIN9 -> DB5
-  | PIN10 -> DB6
-  | PIN11 -> DB7
-  | PIN12 -> DD6
-  | PIN13 -> DC7
-  | MISO -> DB3
-  | SCK -> DB1
-  | MOSI -> DB2
-  | SS -> DB0
-  | PINA0 -> DF7
-  | PINA1 -> DF6
-  | PINA2 -> DF5
-  | PINA3 -> DF4
-  | PINA4 -> DF1
-  | PINA5 -> DF0
-
-
-let input_bit_of_pin : type a b c d. (a register, b register, c register, d analog_pin) pin -> c =
-  function
-  | PIN0 -> ID2
-  | PIN1 -> ID3
-  | PIN2 -> ID1
-  | PIN3 -> ID0
-  | PIN4 -> ID4
-  | PIN5 -> IC6
-  | PIN6 -> ID7
-  | PIN7 -> IE6
-  | PIN8 -> IB4
-  | PIN9 -> IB5
-  | PIN10 -> IB6
-  | PIN11 -> IB7
-  | PIN12 -> ID6
-  | PIN13 -> IC7
-  | MISO -> IB3
-  | SCK -> IB1
-  | MOSI -> IB2
-  | SS -> IB0
-  | PINA0 -> IF7
-  | PINA1 -> IF6
-  | PINA2 -> IF5
-  | PINA3 -> IF4
-  | PINA4 -> IF1
-  | PINA5 -> IF0
-
+  | PIN0 -> D2
+  | PIN1 -> D3
+  | PIN2 -> D1
+  | PIN3 -> D0
+  | PIN4 -> D4
+  | PIN5 -> C6
+  | PIN6 -> D7
+  | PIN7 -> E6
+  | PIN8 -> B4
+  | PIN9 -> B5
+  | PIN10 -> B6
+  | PIN11 -> B7
+  | PIN12 -> D6
+  | PIN13 -> C7
+  | MISO -> B3
+  | SCK -> B1
+  | MOSI -> B2
+  | SS -> B0
+  | PINA0 -> F7
+  | PINA1 -> F6
+  | PINA2 -> F5
+  | PINA3 -> F4
+  | PINA4 -> F1
+  | PINA5 -> F0
 
 external write_register : 'a register -> int -> unit = "caml_avr_write_register" [@@noalloc]
 external read_register : 'a register -> int = "caml_avr_read_register" [@@noalloc]
@@ -256,29 +191,28 @@ let level_of_bool = function false -> LOW | true -> HIGH
 
 let pin_mode p m =
   let port = port_of_pin p in
-  let bit = port_bit_of_pin p in
-  let ddr_bit = ddr_bit_of_pin p in
+  let bit = bit_of_pin p in
   let ddr = ddr_of_pin p in
   match m with
   | OUTPUT ->
-    set_bit ddr ddr_bit
+    set_bit ddr bit
   | INPUT ->
-    clear_bit ddr ddr_bit;
+    clear_bit ddr bit;
     clear_bit port bit
   | INPUT_PULLUP ->
-    clear_bit ddr ddr_bit;
+    clear_bit ddr bit;
     set_bit port bit
 
 let digital_write p b =
   let port = port_of_pin p in
-  let bit = port_bit_of_pin p in
+  let bit = bit_of_pin p in
   match b with
   | HIGH -> set_bit port bit
   | LOW -> clear_bit port bit
 
 let digital_read p =
   let input = input_of_pin p in
-  let ibit = input_bit_of_pin p in
+  let ibit = bit_of_pin p in
   match read_bit input ibit with
   | true -> HIGH
   | false -> LOW

--- a/avrs/arduboy/avr.mli
+++ b/avrs/arduboy/avr.mli
@@ -1,154 +1,71 @@
-type portb_bit = PB0 | PB1 | PB2 | PB3 | PB4 | PB5 | PB6 | PB7
-type portc_bit = PC0 | PC1 | PC2 | PC3 | PC4 | PC5 | PC6 | PC7
-type portd_bit = PD0 | PD1 | PD2 | PD3 | PD4 | PD5 | PD6 | PD7
-type porte_bit = PE0 | PE1 | PE2 | PE3 | PE4 | PE5 | PE6 | PE7
-type portf_bit = PF0 | PF1 | PF2 | PF3 | PF4 | PF5 | PF6 | PF7
-type ddrb_bit = DB0 | DB1 | DB2 | DB3 | DB4 | DB5 | DB6 | DB7
-type ddrc_bit = DC0 | DC1 | DC2 | DC3 | DC4 | DC5 | DC6 | DC7
-type ddrd_bit = DD0 | DD1 | DD2 | DD3 | DD4 | DD5 | DD6 | DD7
-type ddre_bit = DE0 | DE1 | DE2 | DE3 | DE4 | DE5 | DE6 | DE7
-type ddrf_bit = DF0 | DF1 | DF2 | DF3 | DF4 | DF5 | DF6 | DF7
-type pinb_bit = IB0 | IB1 | IB2 | IB3 | IB4 | IB5 | IB6 | IB7
-type pinc_bit = IC0 | IC1 | IC2 | IC3 | IC4 | IC5 | IC6 | IC7
-type pind_bit = ID0 | ID1 | ID2 | ID3 | ID4 | ID5 | ID6 | ID7
-type pine_bit = IE0 | IE1 | IE2 | IE3 | IE4 | IE5 | IE6 | IE7
-type pinf_bit = IF0 | IF1 | IF2 | IF3 | IF4 | IF5 | IF6 | IF7
+type b_bit = B0 | B1 | B2 | B3 | B4 | B5 | B6 | B7
+type c_bit = C0 | C1 | C2 | C3 | C4 | C5 | C6 | C7
+type d_bit = D0 | D1 | D2 | D3 | D4 | D5 | D6 | D7
+type e_bit = E0 | E1 | E2 | E3 | E4 | E5 | E6 | E7
+type f_bit = F0 | F1 | F2 | F3 | F4 | F5 | F6 | F7
 type spcr_bit = SPR0 | SPR1 | CPHA | CPOL | MSTR | DORD | SPE | SPIE
 type spsr_bit = SPI2x | SPSR1 | SPSR2 | SPSR3 | SPSR4 | SPSR5 | SPSR6 | SPIF
 type spdr_bit = SPDR0 | SPDR1 | SPDR2 | SPDR3 | SPDR4 | SPDR5 | SPDR6 | SPDR7
 type 'a register =
-    PORTB : portb_bit register
-  | PORTC : portc_bit register
-  | PORTD : portd_bit register
-  | PORTE : porte_bit register
-  | PORTF : portf_bit register
-  | DDRB : ddrb_bit register
-  | DDRC : ddrc_bit register
-  | DDRD : ddrd_bit register
-  | DDRE : ddre_bit register
-  | DDRF : ddrf_bit register
-  | PINB : pinb_bit register
-  | PINC : pinc_bit register
-  | PIND : pind_bit register
-  | PINE : pine_bit register
-  | PINF : pinf_bit register
+  | PORTB : b_bit register
+  | PORTC : c_bit register
+  | PORTD : d_bit register
+  | PORTE : e_bit register
+  | PORTF : f_bit register
+  | DDRB : b_bit register
+  | DDRC : c_bit register
+  | DDRD : d_bit register
+  | DDRE : e_bit register
+  | DDRF : f_bit register
+  | PINB : b_bit register
+  | PINC : c_bit register
+  | PIND : d_bit register
+  | PINE : e_bit register
+  | PINF : f_bit register
   | SPCR : spcr_bit register
   | SPSR : spsr_bit register
   | SPDR : spsr_bit register
 type yes
 type no
 type 'a analog_pin = YES : yes analog_pin | NO : no analog_pin
-type ('a, 'b, 'c, 'd) pin =
-    PIN0 :
-      (portd_bit register, ddrd_bit register, pind_bit register,
-       no analog_pin)
-      pin
-  | PIN1 :
-      (portd_bit register, ddrd_bit register, pind_bit register,
-       no analog_pin)
-      pin
-  | PIN2 :
-      (portd_bit register, ddrd_bit register, pind_bit register,
-       no analog_pin)
-      pin
-  | PIN3 :
-      (portd_bit register, ddrd_bit register, pind_bit register,
-       no analog_pin)
-      pin
-  | PIN4 :
-      (portd_bit register, ddrd_bit register, pind_bit register,
-       no analog_pin)
-      pin
-  | PIN5 :
-      (portc_bit register, ddrc_bit register, pinc_bit register,
-       no analog_pin)
-      pin
-  | PIN6 :
-      (portd_bit register, ddrd_bit register, pind_bit register,
-       no analog_pin)
-      pin
-  | PIN7 :
-      (porte_bit register, ddre_bit register, pine_bit register,
-       no analog_pin)
-      pin
-  | PIN8 :
-      (portb_bit register, ddrb_bit register, pinb_bit register,
-       no analog_pin)
-      pin
-  | PIN9 :
-      (portb_bit register, ddrb_bit register, pinb_bit register,
-       no analog_pin)
-      pin
-  | PIN10 :
-      (portb_bit register, ddrb_bit register, pinb_bit register,
-       no analog_pin)
-      pin
-  | PIN11 :
-      (portb_bit register, ddrb_bit register, pinb_bit register,
-       no analog_pin)
-      pin
-  | PIN12 :
-      (portd_bit register, ddrd_bit register, pind_bit register,
-       no analog_pin)
-      pin
-  | PIN13 :
-      (portc_bit register, ddrc_bit register, pinc_bit register,
-       no analog_pin)
-      pin
-  | MISO :
-      (portb_bit register, ddrb_bit register, pinb_bit register,
-       no analog_pin)
-      pin
-  | SCK :
-      (portb_bit register, ddrb_bit register, pinb_bit register,
-       no analog_pin)
-      pin
-  | MOSI :
-      (portb_bit register, ddrb_bit register, pinb_bit register,
-       no analog_pin)
-      pin
-  | SS :
-      (portb_bit register, ddrb_bit register, pinb_bit register,
-       no analog_pin)
-      pin
-  | PINA0 :
-      (portf_bit register, ddrf_bit register, pinf_bit register,
-       no analog_pin)
-      pin
-  | PINA1 :
-      (portf_bit register, ddrf_bit register, pinf_bit register,
-       no analog_pin)
-      pin
-  | PINA2 :
-      (portf_bit register, ddrf_bit register, pinf_bit register,
-       no analog_pin)
-      pin
-  | PINA3 :
-      (portf_bit register, ddrf_bit register, pinf_bit register,
-       no analog_pin)
-      pin
-  | PINA4 :
-      (portf_bit register, ddrf_bit register, pinf_bit register,
-       no analog_pin)
-      pin
-  | PINA5 :
-      (portf_bit register, ddrf_bit register, pinf_bit register,
-       no analog_pin)
-      pin
+type 'a pwm_pin = YES : yes pwm_pin | NO : no pwm_pin
+
+type ('a,'b,'c) pin =
+  | PIN0  : (d_bit register, no analog_pin, no pwm_pin) pin
+  | PIN1  : (d_bit register, no analog_pin, no pwm_pin) pin
+  | PIN2  : (d_bit register, no analog_pin, no pwm_pin) pin
+  | PIN3  : (d_bit register, no analog_pin, no pwm_pin) pin
+  | PIN4  : (d_bit register, no analog_pin, no pwm_pin) pin
+  | PIN5  : (c_bit register, no analog_pin, no pwm_pin) pin
+  | PIN6  : (d_bit register, no analog_pin, no pwm_pin) pin
+  | PIN7  : (e_bit register, no analog_pin, no pwm_pin) pin
+  | PIN8  : (b_bit register, no analog_pin, no pwm_pin) pin
+  | PIN9  : (b_bit register, no analog_pin, no pwm_pin) pin
+  | PIN10 : (b_bit register, no analog_pin, no pwm_pin) pin
+  | PIN11 : (b_bit register, no analog_pin, no pwm_pin) pin
+  | PIN12 : (d_bit register, no analog_pin, no pwm_pin) pin
+  | PIN13 : (c_bit register, no analog_pin, no pwm_pin) pin
+  | MISO  : (b_bit register, no analog_pin, no pwm_pin) pin
+  | SCK   : (b_bit register, no analog_pin, no pwm_pin) pin
+  | MOSI  : (b_bit register, no analog_pin, no pwm_pin) pin
+  | SS    : (b_bit register, no analog_pin, no pwm_pin) pin
+  | PINA0 : (f_bit register, no analog_pin, no pwm_pin) pin
+  | PINA1 : (f_bit register, no analog_pin, no pwm_pin) pin
+  | PINA2 : (f_bit register, no analog_pin, no pwm_pin) pin
+  | PINA3 : (f_bit register, no analog_pin, no pwm_pin) pin
+  | PINA4 : (f_bit register, no analog_pin, no pwm_pin) pin
+  | PINA5 : (f_bit register, no analog_pin, no pwm_pin) pin
+
 type mode = INPUT | OUTPUT | INPUT_PULLUP
 type level = LOW | HIGH
 val port_of_pin :
-  ('a register, 'b register, 'c register, 'd analog_pin) pin -> 'a register
+  ('a register, 'b analog_pin, 'c pwm_pin) pin -> 'a register
 val ddr_of_pin :
-  ('a register, 'b register, 'c register, 'd analog_pin) pin -> 'b register
+  ('a register, 'b analog_pin, 'c pwm_pin) pin -> 'a register
 val input_of_pin :
-  ('a register, 'b register, 'c register, 'd analog_pin) pin -> 'c register
-val port_bit_of_pin :
-  ('a register, 'b register, 'c register, 'd analog_pin) pin -> 'a
-val ddr_bit_of_pin :
-  ('a register, 'b register, 'c register, 'd analog_pin) pin -> 'b
-val input_bit_of_pin :
-  ('a register, 'b register, 'c register, 'd analog_pin) pin -> 'c
+  ('a register, 'b analog_pin, 'c pwm_pin) pin -> 'a register
+val bit_of_pin :
+  ('a register, 'b analog_pin, 'c pwm_pin) pin -> 'a
 external write_register : 'a register -> int -> unit
   = "caml_avr_write_register" [@@noalloc]
 external read_register : 'a register -> int = "caml_avr_read_register"
@@ -163,11 +80,11 @@ external millis : unit -> int = "caml_avr_millis" [@@noalloc]
 val bool_of_level : level -> bool
 val level_of_bool : bool -> level
 val pin_mode :
-  ('a register, 'b register, 'c register, 'd analog_pin) pin -> mode -> unit
+  ('a register, 'b analog_pin, 'c pwm_pin) pin -> mode -> unit
 val digital_write :
-  ('a register, 'b register, 'c register, 'd analog_pin) pin -> level -> unit
+  ('a register, 'b analog_pin, 'c pwm_pin) pin -> level -> unit
 val digital_read :
-  ('a register, 'b register, 'c register, 'd analog_pin) pin -> level
+  ('a register, 'b analog_pin, 'c pwm_pin) pin -> level
 module Serial :
   sig
     external init : unit -> unit = "caml_avr_serial_init" [@@noalloc]

--- a/avrs/arduino_mega_2560/avr.ml
+++ b/avrs/arduino_mega_2560/avr.ml
@@ -1,77 +1,53 @@
-type porta_bit = PA0 | PA1 | PA2 | PA3 | PA4 | PA5 | PA6 | PA7
-type portb_bit = PB0 | PB1 | PB2 | PB3 | PB4 | PB5 | PB6 | PB7
-type portc_bit = PC0 | PC1 | PC2 | PC3 | PC4 | PC5 | PC6 | PC7
-type portd_bit = PD0 | PD1 | PD2 | PD3 | PD4 | PD5 | PD6 | PD7
-type porte_bit = PE0 | PE1 | PE2 | PE3 | PE4 | PE5 | PE6 | PE7
-type portf_bit = PF0 | PF1 | PF2 | PF3 | PF4 | PF5 | PF6 | PF7
-type portg_bit = PG0 | PG1 | PG2 | PG3 | PG4 | PG5 | PG6 | PG7
-type porth_bit = PH0 | PH1 | PH2 | PH3 | PH4 | PH5 | PH6 | PH7
-type portj_bit = PJ0 | PJ1 | PJ2 | PJ3 | PJ4 | PJ5 | PJ6 | PJ7
-type portl_bit = PL0 | PL1 | PL2 | PL3 | PL4 | PL5 | PL6 | PL7
-type portk_bit = PK0 | PK1 | PK2 | PK3 | PK4 | PK5 | PK6 | PK7
-
-type ddra_bit = DA0 | DA1 | DA2 | DA3 | DA4 | DA5 | DA6 | DA7
-type ddrb_bit = DB0 | DB1 | DB2 | DB3 | DB4 | DB5 | DB6 | DB7
-type ddrc_bit = DC0 | DC1 | DC2 | DC3 | DC4 | DC5 | DC6 | DC7
-type ddrd_bit = DD0 | DD1 | DD2 | DD3 | DD4 | DD5 | DD6 | DD7
-type ddre_bit = DE0 | DE1 | DE2 | DE3 | DE4 | DE5 | DE6 | DE7
-type ddrf_bit = DF0 | DF1 | DF2 | DF3 | DF4 | DF5 | DF6 | DF7
-type ddrg_bit = DG0 | DG1 | DG2 | DG3 | DG4 | DG5 | DG6 | DG7
-type ddrh_bit = DH0 | DH1 | DH2 | DH3 | DH4 | DH5 | DH6 | DH7
-type ddrj_bit = DJ0 | DJ1 | DJ2 | DJ3 | DJ4 | DJ5 | DJ6 | DJ7
-type ddrl_bit = DL0 | DL1 | DL2 | DL3 | DL4 | DL5 | DL6 | DL7
-type ddrk_bit = DK0 | DK1 | DK2 | DK3 | DK4 | DK5 | DK6 | DK7
-
-type pina_bit = IA0 | IA1 | IA2 | IA3 | IA4 | IA5 | IA6 | IA7
-type pinb_bit = IB0 | IB1 | IB2 | IB3 | IB4 | IB5 | IB6 | IB7
-type pinc_bit = IC0 | IC1 | IC2 | IC3 | IC4 | IC5 | IC6 | IC7
-type pind_bit = ID0 | ID1 | ID2 | ID3 | ID4 | ID5 | ID6 | ID7
-type pine_bit = IE0 | IE1 | IE2 | IE3 | IE4 | IE5 | IE6 | IE7
-type pinf_bit = IF0 | IF1 | IF2 | IF3 | IF4 | IF5 | IF6 | IF7
-type ping_bit = IG0 | IG1 | IG2 | IG3 | IG4 | IG5 | IG6 | IG7
-type pinh_bit = IH0 | IH1 | IH2 | IH3 | IH4 | IH5 | IH6 | IH7
-type pinj_bit = IJ0 | IJ1 | IJ2 | IJ3 | IJ4 | IJ5 | IJ6 | IJ7
-type pinl_bit = IL0 | IL1 | IL2 | IL3 | IL4 | IL5 | IL6 | IL7
-type pink_bit = IK0 | IK1 | IK2 | IK3 | IK4 | IK5 | IK6 | IK7
+type a_bit = A0 | A1 | A2 | A3 | A4 | A5 | A6 | A7
+type b_bit = B0 | B1 | B2 | B3 | B4 | B5 | B6 | B7
+type c_bit = C0 | C1 | C2 | C3 | C4 | C5 | C6 | C7
+type d_bit = D0 | D1 | D2 | D3 | D4 | D5 | D6 | D7
+type e_bit = E0 | E1 | E2 | E3 | E4 | E5 | E6 | E7
+type f_bit = F0 | F1 | F2 | F3 | F4 | F5 | F6 | F7
+type g_bit = G0 | G1 | G2 | G3 | G4 | G5 | G6 | G7
+type h_bit = H0 | H1 | H2 | H3 | H4 | H5 | H6 | H7
+type j_bit = J0 | J1 | J2 | J3 | J4 | J5 | J6 | J7
+type l_bit = L0 | L1 | L2 | L3 | L4 | L5 | L6 | L7
+type k_bit = K0 | K1 | K2 | K3 | K4 | K5 | K6 | K7
 
 type spcr_bit = SPR0 | SPR1 | CPHA | CPOL | MSTR | DORD | SPE | SPIE
 type spsr_bit = SPI2x | SPSR1 | SPSR2 | SPSR3 | SPSR4 | SPSR5 | SPSR6 | SPIF
 type spdr_bit = SPDR0 | SPDR1 | SPDR2 | SPDR3 | SPDR4 | SPDR5 | SPDR6 | SPDR7
 
 type 'a register =
-  | PORTA : porta_bit register
-  | PORTB : portb_bit register
-  | PORTC : portc_bit register
-  | PORTD : portd_bit register
-  | PORTE : porte_bit register
-  | PORTF : portf_bit register
-  | PORTG : portg_bit register
-  | PORTH : porth_bit register
-  | PORTJ : portj_bit register
-  | PORTK : portk_bit register
-  | PORTL : portl_bit register
-  | DDRA : ddra_bit register
-  | DDRB : ddrb_bit register
-  | DDRC : ddrc_bit register
-  | DDRD : ddrd_bit register
-  | DDRE : ddre_bit register
-  | DDRF : ddrf_bit register
-  | DDRG : ddrg_bit register
-  | DDRH : ddrh_bit register
-  | DDRJ : ddrj_bit register
-  | DDRK : ddrk_bit register
-  | DDRL : ddrl_bit register
-  | PINA : pina_bit register
-  | PINB : pinb_bit register
-  | PINC : pinc_bit register
-  | PIND : pind_bit register
-  | PINE : pine_bit register
-  | PINF : pinf_bit register
-  | PING : ping_bit register
-  | PINH : pinh_bit register
-  | PINJ : pinj_bit register
-  | PINK : pink_bit register
-  | PINL : pinl_bit register
+  | PORTA : a_bit register
+  | PORTB : b_bit register
+  | PORTC : c_bit register
+  | PORTD : d_bit register
+  | PORTE : e_bit register
+  | PORTF : f_bit register
+  | PORTG : g_bit register
+  | PORTH : h_bit register
+  | PORTJ : j_bit register
+  | PORTK : k_bit register
+  | PORTL : l_bit register
+  | DDRA : a_bit register
+  | DDRB : b_bit register
+  | DDRC : c_bit register
+  | DDRD : d_bit register
+  | DDRE : e_bit register
+  | DDRF : f_bit register
+  | DDRG : g_bit register
+  | DDRH : h_bit register
+  | DDRJ : j_bit register
+  | DDRK : k_bit register
+  | DDRL : l_bit register
+  | PINA : a_bit register
+  | PINB : b_bit register
+  | PINC : c_bit register
+  | PIND : d_bit register
+  | PINE : e_bit register
+  | PINF : f_bit register
+  | PING : g_bit register
+  | PINH : h_bit register
+  | PINJ : j_bit register
+  | PINK : k_bit register
+  | PINL : l_bit register
   | SPCR : spcr_bit register
   | SPSR : spsr_bit register
   | SPDR : spsr_bit register
@@ -81,84 +57,87 @@ type no
 type 'a analog_pin =
   | YES : yes analog_pin
   | NO : no analog_pin
+type 'a pwm_pin =
+  | YES : yes pwm_pin
+  | NO : no pwm_pin
 
-type ('a,'b,'c,'d) pin =
-  | PIN0  : (porte_bit register, ddre_bit register, pine_bit register, no analog_pin) pin
-  | PIN1  : (porte_bit register, ddre_bit register, pine_bit register, no analog_pin) pin
-  | PIN2  : (porte_bit register, ddre_bit register, pine_bit register, no analog_pin) pin
-  | PIN3  : (porte_bit register, ddre_bit register, pine_bit register, no analog_pin) pin
-  | PIN4  : (portg_bit register, ddrg_bit register, ping_bit register, no analog_pin) pin
-  | PIN5  : (porte_bit register, ddre_bit register, pine_bit register, no analog_pin) pin
-  | PIN6  : (porth_bit register, ddrh_bit register, pinh_bit register, no analog_pin) pin
-  | PIN7  : (porth_bit register, ddrh_bit register, pinh_bit register, no analog_pin) pin
-  | PIN8  : (porth_bit register, ddrh_bit register, pinh_bit register, no analog_pin) pin
-  | PIN9  : (porth_bit register, ddrh_bit register, pinh_bit register, no analog_pin) pin
-  | PIN10 : (portb_bit register, ddrb_bit register, pinb_bit register, no analog_pin) pin
-  | PIN11 : (portb_bit register, ddrb_bit register, pinb_bit register, no analog_pin) pin
-  | PIN12 : (portb_bit register, ddrb_bit register, pinb_bit register, no analog_pin) pin
-  | PIN13 : (portb_bit register, ddrb_bit register, pinb_bit register, no analog_pin) pin
-  | PIN14 : (portj_bit register, ddrj_bit register, pinj_bit register, no analog_pin) pin
-  | PIN15 : (portj_bit register, ddrj_bit register, pinj_bit register, no analog_pin) pin
-  | PIN16 : (porth_bit register, ddrh_bit register, pinh_bit register, no analog_pin) pin
-  | PIN17 : (porth_bit register, ddrh_bit register, pinh_bit register, no analog_pin) pin
-  | PIN18 : (portd_bit register, ddrd_bit register, pind_bit register, no analog_pin) pin
-  | PIN19 : (portd_bit register, ddrd_bit register, pind_bit register, no analog_pin) pin
-  | PIN20 : (portd_bit register, ddrd_bit register, pind_bit register, no analog_pin) pin
-  | PIN21 : (portd_bit register, ddrd_bit register, pind_bit register, no analog_pin) pin
-  | PIN22 : (porta_bit register, ddra_bit register, pina_bit register, no analog_pin) pin
-  | PIN23 : (porta_bit register, ddra_bit register, pina_bit register, no analog_pin) pin
-  | PIN24 : (porta_bit register, ddra_bit register, pina_bit register, no analog_pin) pin
-  | PIN25 : (porta_bit register, ddra_bit register, pina_bit register, no analog_pin) pin
-  | PIN26 : (porta_bit register, ddra_bit register, pina_bit register, no analog_pin) pin
-  | PIN27 : (porta_bit register, ddra_bit register, pina_bit register, no analog_pin) pin
-  | PIN28 : (porta_bit register, ddra_bit register, pina_bit register, no analog_pin) pin
-  | PIN29 : (porta_bit register, ddra_bit register, pina_bit register, no analog_pin) pin
-  | PIN30 : (portc_bit register, ddrc_bit register, pinc_bit register, no analog_pin) pin
-  | PIN31 : (portc_bit register, ddrc_bit register, pinc_bit register, no analog_pin) pin
-  | PIN32 : (portc_bit register, ddrc_bit register, pinc_bit register, no analog_pin) pin
-  | PIN33 : (portc_bit register, ddrc_bit register, pinc_bit register, no analog_pin) pin
-  | PIN34 : (portc_bit register, ddrc_bit register, pinc_bit register, no analog_pin) pin
-  | PIN35 : (portc_bit register, ddrc_bit register, pinc_bit register, no analog_pin) pin
-  | PIN36 : (portc_bit register, ddrc_bit register, pinc_bit register, no analog_pin) pin
-  | PIN37 : (portc_bit register, ddrc_bit register, pinc_bit register, no analog_pin) pin
-  | PIN38 : (portd_bit register, ddrd_bit register, pind_bit register, no analog_pin) pin
-  | PIN39 : (portg_bit register, ddrg_bit register, ping_bit register, no analog_pin) pin
-  | PIN40 : (portg_bit register, ddrg_bit register, ping_bit register, no analog_pin) pin
-  | PIN41 : (portg_bit register, ddrg_bit register, ping_bit register, no analog_pin) pin
-  | PIN42 : (portl_bit register, ddrl_bit register, pinl_bit register, no analog_pin) pin
-  | PIN43 : (portl_bit register, ddrl_bit register, pinl_bit register, no analog_pin) pin
-  | PIN44 : (portl_bit register, ddrl_bit register, pinl_bit register, no analog_pin) pin
-  | PIN45 : (portl_bit register, ddrl_bit register, pinl_bit register, no analog_pin) pin
-  | PIN46 : (portl_bit register, ddrl_bit register, pinl_bit register, no analog_pin) pin
-  | PIN47 : (portl_bit register, ddrl_bit register, pinl_bit register, no analog_pin) pin
-  | PIN48 : (portl_bit register, ddrl_bit register, pinl_bit register, no analog_pin) pin
-  | PIN49 : (portl_bit register, ddrl_bit register, pinl_bit register, no analog_pin) pin
-  | MISO  : (portb_bit register, ddrb_bit register, pinb_bit register, no analog_pin) pin
-  | SCK   : (portb_bit register, ddrb_bit register, pinb_bit register, no analog_pin) pin
-  | MOSI  : (portb_bit register, ddrb_bit register, pinb_bit register, no analog_pin) pin
-  | SS    : (portb_bit register, ddrb_bit register, pinb_bit register, no analog_pin) pin
-  | PINA0 : (portf_bit register, ddrf_bit register, pinf_bit register, yes analog_pin) pin
-  | PINA1 : (portf_bit register, ddrf_bit register, pinf_bit register, yes analog_pin) pin
-  | PINA2 : (portf_bit register, ddrf_bit register, pinf_bit register, yes analog_pin) pin
-  | PINA3 : (portf_bit register, ddrf_bit register, pinf_bit register, yes analog_pin) pin
-  | PINA4 : (portf_bit register, ddrf_bit register, pinf_bit register, yes analog_pin) pin
-  | PINA5 : (portf_bit register, ddrf_bit register, pinf_bit register, yes analog_pin) pin
-  | PINA6 : (portf_bit register, ddrf_bit register, pinf_bit register, yes analog_pin) pin
-  | PINA7 : (portf_bit register, ddrf_bit register, pinf_bit register, yes analog_pin) pin
-  | PINA8 : (portk_bit register, ddrk_bit register, pink_bit register, yes analog_pin) pin
-  | PINA9 : (portk_bit register, ddrk_bit register, pink_bit register, yes analog_pin) pin
-  | PINA10 : (portk_bit register, ddrk_bit register, pink_bit register, yes analog_pin) pin
-  | PINA11 : (portk_bit register, ddrk_bit register, pink_bit register, yes analog_pin) pin
-  | PINA12 : (portk_bit register, ddrk_bit register, pink_bit register, yes analog_pin) pin
-  | PINA13 : (portk_bit register, ddrk_bit register, pink_bit register, yes analog_pin) pin
-  | PINA14 : (portk_bit register, ddrk_bit register, pink_bit register, yes analog_pin) pin
-  | PINA15 : (portk_bit register, ddrk_bit register, pink_bit register, yes analog_pin) pin
+type ('a,'b,'c) pin =
+  | PIN0  : (e_bit register, no analog_pin, no pwm_pin) pin
+  | PIN1  : (e_bit register, no analog_pin, no pwm_pin) pin
+  | PIN2  : (e_bit register, no analog_pin, yes pwm_pin) pin
+  | PIN3  : (e_bit register, no analog_pin, yes pwm_pin) pin
+  | PIN4  : (g_bit register, no analog_pin, yes pwm_pin) pin
+  | PIN5  : (e_bit register, no analog_pin, yes pwm_pin) pin
+  | PIN6  : (h_bit register, no analog_pin, yes pwm_pin) pin
+  | PIN7  : (h_bit register, no analog_pin, yes pwm_pin) pin
+  | PIN8  : (h_bit register, no analog_pin, yes pwm_pin) pin
+  | PIN9  : (h_bit register, no analog_pin, yes pwm_pin) pin
+  | PIN10 : (b_bit register, no analog_pin, yes pwm_pin) pin
+  | PIN11 : (b_bit register, no analog_pin, yes pwm_pin) pin
+  | PIN12 : (b_bit register, no analog_pin, yes pwm_pin) pin
+  | PIN13 : (b_bit register, no analog_pin, yes pwm_pin) pin
+  | PIN14 : (j_bit register, no analog_pin, no pwm_pin) pin
+  | PIN15 : (j_bit register, no analog_pin, no pwm_pin) pin
+  | PIN16 : (h_bit register, no analog_pin, no pwm_pin) pin
+  | PIN17 : (h_bit register, no analog_pin, no pwm_pin) pin
+  | PIN18 : (d_bit register, no analog_pin, no pwm_pin) pin
+  | PIN19 : (d_bit register, no analog_pin, no pwm_pin) pin
+  | PIN20 : (d_bit register, no analog_pin, no pwm_pin) pin
+  | PIN21 : (d_bit register, no analog_pin, no pwm_pin) pin
+  | PIN22 : (a_bit register, no analog_pin, no pwm_pin) pin
+  | PIN23 : (a_bit register, no analog_pin, no pwm_pin) pin
+  | PIN24 : (a_bit register, no analog_pin, no pwm_pin) pin
+  | PIN25 : (a_bit register, no analog_pin, no pwm_pin) pin
+  | PIN26 : (a_bit register, no analog_pin, no pwm_pin) pin
+  | PIN27 : (a_bit register, no analog_pin, no pwm_pin) pin
+  | PIN28 : (a_bit register, no analog_pin, no pwm_pin) pin
+  | PIN29 : (a_bit register, no analog_pin, no pwm_pin) pin
+  | PIN30 : (c_bit register, no analog_pin, no pwm_pin) pin
+  | PIN31 : (c_bit register, no analog_pin, no pwm_pin) pin
+  | PIN32 : (c_bit register, no analog_pin, no pwm_pin) pin
+  | PIN33 : (c_bit register, no analog_pin, no pwm_pin) pin
+  | PIN34 : (c_bit register, no analog_pin, no pwm_pin) pin
+  | PIN35 : (c_bit register, no analog_pin, no pwm_pin) pin
+  | PIN36 : (c_bit register, no analog_pin, no pwm_pin) pin
+  | PIN37 : (c_bit register, no analog_pin, no pwm_pin) pin
+  | PIN38 : (d_bit register, no analog_pin, no pwm_pin) pin
+  | PIN39 : (g_bit register, no analog_pin, no pwm_pin) pin
+  | PIN40 : (g_bit register, no analog_pin, no pwm_pin) pin
+  | PIN41 : (g_bit register, no analog_pin, no pwm_pin) pin
+  | PIN42 : (l_bit register, no analog_pin, no pwm_pin) pin
+  | PIN43 : (l_bit register, no analog_pin, no pwm_pin) pin
+  | PIN44 : (l_bit register, no analog_pin, yes pwm_pin) pin
+  | PIN45 : (l_bit register, no analog_pin, yes pwm_pin) pin
+  | PIN46 : (l_bit register, no analog_pin, yes pwm_pin) pin
+  | PIN47 : (l_bit register, no analog_pin, no pwm_pin) pin
+  | PIN48 : (l_bit register, no analog_pin, no pwm_pin) pin
+  | PIN49 : (l_bit register, no analog_pin, no pwm_pin) pin
+  | MISO  : (b_bit register, no analog_pin, no pwm_pin) pin
+  | SCK   : (b_bit register, no analog_pin, no pwm_pin) pin
+  | MOSI  : (b_bit register, no analog_pin, no pwm_pin) pin
+  | SS    : (b_bit register, no analog_pin, no pwm_pin) pin
+  | PINA0 : (f_bit register, yes analog_pin, no pwm_pin) pin
+  | PINA1 : (f_bit register, yes analog_pin, no pwm_pin) pin
+  | PINA2 : (f_bit register, yes analog_pin, no pwm_pin) pin
+  | PINA3 : (f_bit register, yes analog_pin, no pwm_pin) pin
+  | PINA4 : (f_bit register, yes analog_pin, no pwm_pin) pin
+  | PINA5 : (f_bit register, yes analog_pin, no pwm_pin) pin
+  | PINA6 : (f_bit register, yes analog_pin, no pwm_pin) pin
+  | PINA7 : (f_bit register, yes analog_pin, no pwm_pin) pin
+  | PINA8 : (k_bit register, yes analog_pin, no pwm_pin) pin
+  | PINA9 : (k_bit register, yes analog_pin, no pwm_pin) pin
+  | PINA10 : (k_bit register, yes analog_pin, no pwm_pin) pin
+  | PINA11 : (k_bit register, yes analog_pin, no pwm_pin) pin
+  | PINA12 : (k_bit register, yes analog_pin, no pwm_pin) pin
+  | PINA13 : (k_bit register, yes analog_pin, no pwm_pin) pin
+  | PINA14 : (k_bit register, yes analog_pin, no pwm_pin) pin
+  | PINA15 : (k_bit register, yes analog_pin, no pwm_pin) pin
 
 type mode = INPUT | OUTPUT | INPUT_PULLUP
 
 type level = LOW | HIGH
 
-let port_of_pin : type a b c d. (a register,b register, c register, d analog_pin) pin -> a register =
+let port_of_pin : type a b c. (a register, b analog_pin, c pwm_pin) pin -> a register =
   function
   | PIN0 -> PORTE
   | PIN1 -> PORTE
@@ -231,7 +210,7 @@ let port_of_pin : type a b c d. (a register,b register, c register, d analog_pin
   | PINA14 -> PORTK
   | PINA15 -> PORTK
 
-let ddr_of_pin : type a b c d. (a register , b register, c register, d analog_pin) pin -> b register=
+let ddr_of_pin : type a b c. (a register , b analog_pin, c pwm_pin) pin -> a register=
   function
   | PIN0 -> DDRE
   | PIN1 -> DDRE
@@ -305,7 +284,7 @@ let ddr_of_pin : type a b c d. (a register , b register, c register, d analog_pi
   | PINA15 -> DDRK
 
 
-let input_of_pin : type a b c d. (a register , b register, c register, d analog_pin) pin -> c register=
+let input_of_pin : type a b c. (a register , b analog_pin, c pwm_pin) pin -> a register=
   function
   | PIN0 -> PINE
   | PIN1 -> PINE
@@ -378,228 +357,78 @@ let input_of_pin : type a b c d. (a register , b register, c register, d analog_
   | PINA14 -> PINK
   | PINA15 -> PINK
 
-let port_bit_of_pin : type a b c d. (a register, b register, c register, d analog_pin) pin -> a =
+let bit_of_pin : type a b c. (a register, b analog_pin, c pwm_pin) pin -> a =
   function
-  | PIN0 -> PE0
-  | PIN1 -> PE1
-  | PIN2 -> PE4
-  | PIN3 -> PE5
-  | PIN4 -> PG5
-  | PIN5 -> PE3
-  | PIN6 -> PH3
-  | PIN7 -> PH4
-  | PIN8 -> PH5
-  | PIN9 -> PH6
-  | PIN10 -> PB4
-  | PIN11 -> PB5
-  | PIN12 -> PB6
-  | PIN13 -> PB7
-  | PIN14 -> PJ1
-  | PIN15 -> PJ0
-  | PIN16 -> PH1
-  | PIN17 -> PH0
-  | PIN18 -> PD3
-  | PIN19 -> PD2
-  | PIN20 -> PD1
-  | PIN21 -> PD0
-  | PIN22 -> PA0
-  | PIN23 -> PA1
-  | PIN24 -> PA2
-  | PIN25 -> PA3
-  | PIN26 -> PA4
-  | PIN27 -> PA5
-  | PIN28 -> PA6
-  | PIN29 -> PA7
-  | PIN30 -> PC7
-  | PIN31 -> PC6
-  | PIN32 -> PC5
-  | PIN33 -> PC4
-  | PIN34 -> PC3
-  | PIN35 -> PC2
-  | PIN36 -> PC1
-  | PIN37 -> PC0
-  | PIN38 -> PD7
-  | PIN39 -> PG2
-  | PIN40 -> PG1
-  | PIN41 -> PG0
-  | PIN42 -> PL7
-  | PIN43 -> PL6
-  | PIN44 -> PL5
-  | PIN45 -> PL4
-  | PIN46 -> PL3
-  | PIN47 -> PL2
-  | PIN48 -> PL1
-  | PIN49 -> PL0
-  | MISO -> PB3
-  | SCK -> PB1
-  | MOSI -> PB2
-  | SS -> PB0
-  | PINA0 -> PF0
-  | PINA1 -> PF1
-  | PINA2 -> PF2
-  | PINA3 -> PF3
-  | PINA4 -> PF4
-  | PINA5 -> PF5
-  | PINA6 -> PF6
-  | PINA7 -> PF7
-  | PINA8 -> PK0
-  | PINA9 -> PK1
-  | PINA10 -> PK2
-  | PINA11 -> PK3
-  | PINA12 -> PK4
-  | PINA13 -> PK5
-  | PINA14 -> PK6
-  | PINA15 -> PK7
-
-
-let ddr_bit_of_pin : type a b c d. (a register, b register, c register, d analog_pin) pin -> b =
-  function
-  | PIN0 -> DE0
-  | PIN1 -> DE1
-  | PIN2 -> DE4
-  | PIN3 -> DE5
-  | PIN4 -> DG5
-  | PIN5 -> DE3
-  | PIN6 -> DH3
-  | PIN7 -> DH4
-  | PIN8 -> DH5
-  | PIN9 -> DH6
-  | PIN10 -> DB4
-  | PIN11 -> DB5
-  | PIN12 -> DB6
-  | PIN13 -> DB7
-  | PIN14 -> DJ1
-  | PIN15 -> DJ0
-  | PIN16 -> DH1
-  | PIN17 -> DH0
-  | PIN18 -> DD3
-  | PIN19 -> DD2
-  | PIN20 -> DD1
-  | PIN21 -> DD0
-  | PIN22 -> DA0
-  | PIN23 -> DA1
-  | PIN24 -> DA2
-  | PIN25 -> DA3
-  | PIN26 -> DA4
-  | PIN27 -> DA5
-  | PIN28 -> DA6
-  | PIN29 -> DA7
-  | PIN30 -> DC7
-  | PIN31 -> DC6
-  | PIN32 -> DC5
-  | PIN33 -> DC4
-  | PIN34 -> DC3
-  | PIN35 -> DC2
-  | PIN36 -> DC1
-  | PIN37 -> DC0
-  | PIN38 -> DD7
-  | PIN39 -> DG2
-  | PIN40 -> DG1
-  | PIN41 -> DG0
-  | PIN42 -> DL7
-  | PIN43 -> DL6
-  | PIN44 -> DL5
-  | PIN45 -> DL4
-  | PIN46 -> DL3
-  | PIN47 -> DL2
-  | PIN48 -> DL1
-  | PIN49 -> DL0
-  | MISO -> DB3
-  | SCK -> DB1
-  | MOSI -> DB2
-  | SS -> DB0
-  | PINA0 -> DF0
-  | PINA1 -> DF1
-  | PINA2 -> DF2
-  | PINA3 -> DF3
-  | PINA4 -> DF4
-  | PINA5 -> DF5
-  | PINA6 -> DF6
-  | PINA7 -> DF7
-  | PINA8 -> DK0
-  | PINA9 -> DK1
-  | PINA10 -> DK2
-  | PINA11 -> DK3
-  | PINA12 -> DK4
-  | PINA13 -> DK5
-  | PINA14 -> DK6
-  | PINA15 -> DK7
-
-
-
-let input_bit_of_pin : type a b c d. (a register, b register, c register, d analog_pin) pin -> c =
-  function
-  | PIN0 -> IE0
-  | PIN1 -> IE1
-  | PIN2 -> IE4
-  | PIN3 -> IE5
-  | PIN4 -> IG5
-  | PIN5 -> IE3
-  | PIN6 -> IH3
-  | PIN7 -> IH4
-  | PIN8 -> IH5
-  | PIN9 -> IH6
-  | PIN10 -> IB4
-  | PIN11 -> IB5
-  | PIN12 -> IB6
-  | PIN13 -> IB7
-  | PIN14 -> IJ1
-  | PIN15 -> IJ0
-  | PIN16 -> IH1
-  | PIN17 -> IH0
-  | PIN18 -> ID3
-  | PIN19 -> ID2
-  | PIN20 -> ID1
-  | PIN21 -> ID0
-  | PIN22 -> IA0
-  | PIN23 -> IA1
-  | PIN24 -> IA2
-  | PIN25 -> IA3
-  | PIN26 -> IA4
-  | PIN27 -> IA5
-  | PIN28 -> IA6
-  | PIN29 -> IA7
-  | PIN30 -> IC7
-  | PIN31 -> IC6
-  | PIN32 -> IC5
-  | PIN33 -> IC4
-  | PIN34 -> IC3
-  | PIN35 -> IC2
-  | PIN36 -> IC1
-  | PIN37 -> IC0
-  | PIN38 -> ID7
-  | PIN39 -> IG2
-  | PIN40 -> IG1
-  | PIN41 -> IG0
-  | PIN42 -> IL7
-  | PIN43 -> IL6
-  | PIN44 -> IL5
-  | PIN45 -> IL4
-  | PIN46 -> IL3
-  | PIN47 -> IL2
-  | PIN48 -> IL1
-  | PIN49 -> IL0
-  | MISO -> IB3
-  | SCK -> IB1
-  | MOSI -> IB2
-  | SS -> IB0
-  | PINA0 -> IF0
-  | PINA1 -> IF1
-  | PINA2 -> IF2
-  | PINA3 -> IF3
-  | PINA4 -> IF4
-  | PINA5 -> IF5
-  | PINA6 -> IF6
-  | PINA7 -> IF7
-  | PINA8 -> IK0
-  | PINA9 -> IK1
-  | PINA10 -> IK2
-  | PINA11 -> IK3
-  | PINA12 -> IK4
-  | PINA13 -> IK5
-  | PINA14 -> IK6
-  | PINA15 -> IK7
-
+  | PIN0 -> E0
+  | PIN1 -> E1
+  | PIN2 -> E4
+  | PIN3 -> E5
+  | PIN4 -> G5
+  | PIN5 -> E3
+  | PIN6 -> H3
+  | PIN7 -> H4
+  | PIN8 -> H5
+  | PIN9 -> H6
+  | PIN10 -> B4
+  | PIN11 -> B5
+  | PIN12 -> B6
+  | PIN13 -> B7
+  | PIN14 -> J1
+  | PIN15 -> J0
+  | PIN16 -> H1
+  | PIN17 -> H0
+  | PIN18 -> D3
+  | PIN19 -> D2
+  | PIN20 -> D1
+  | PIN21 -> D0
+  | PIN22 -> A0
+  | PIN23 -> A1
+  | PIN24 -> A2
+  | PIN25 -> A3
+  | PIN26 -> A4
+  | PIN27 -> A5
+  | PIN28 -> A6
+  | PIN29 -> A7
+  | PIN30 -> C7
+  | PIN31 -> C6
+  | PIN32 -> C5
+  | PIN33 -> C4
+  | PIN34 -> C3
+  | PIN35 -> C2
+  | PIN36 -> C1
+  | PIN37 -> C0
+  | PIN38 -> D7
+  | PIN39 -> G2
+  | PIN40 -> G1
+  | PIN41 -> G0
+  | PIN42 -> L7
+  | PIN43 -> L6
+  | PIN44 -> L5
+  | PIN45 -> L4
+  | PIN46 -> L3
+  | PIN47 -> L2
+  | PIN48 -> L1
+  | PIN49 -> L0
+  | MISO -> B3
+  | SCK -> B1
+  | MOSI -> B2
+  | SS -> B0
+  | PINA0 -> F0
+  | PINA1 -> F1
+  | PINA2 -> F2
+  | PINA3 -> F3
+  | PINA4 -> F4
+  | PINA5 -> F5
+  | PINA6 -> F6
+  | PINA7 -> F7
+  | PINA8 -> K0
+  | PINA9 -> K1
+  | PINA10 -> K2
+  | PINA11 -> K3
+  | PINA12 -> K4
+  | PINA13 -> K5
+  | PINA14 -> K6
+  | PINA15 -> K7
 
 external write_register : 'a register -> int -> unit = "caml_avr_write_register" [@@noalloc]
 external read_register : 'a register -> int = "caml_avr_read_register" [@@noalloc]
@@ -614,29 +443,28 @@ let level_of_bool = function false -> LOW | true -> HIGH
 
 let pin_mode p m =
   let port = port_of_pin p in
-  let bit = port_bit_of_pin p in
-  let ddr_bit = ddr_bit_of_pin p in
+  let bit = bit_of_pin p in
   let ddr = ddr_of_pin p in
   match m with
   | OUTPUT ->
-    set_bit ddr ddr_bit
+    set_bit ddr bit
   | INPUT ->
-    clear_bit ddr ddr_bit;
+    clear_bit ddr bit;
     clear_bit port bit
   | INPUT_PULLUP ->
-    clear_bit ddr ddr_bit;
+    clear_bit ddr bit;
     set_bit port bit
 
 let digital_write p b =
   let port = port_of_pin p in
-  let bit = port_bit_of_pin p in
+  let bit = bit_of_pin p in
   match b with
   | HIGH -> set_bit port bit
   | LOW -> clear_bit port bit
 
 let digital_read p =
   let input = input_of_pin p in
-  let ibit = input_bit_of_pin p in
+  let ibit = bit_of_pin p in
   match read_bit input ibit with
   | true -> HIGH
   | false -> LOW
@@ -646,7 +474,7 @@ external adc_init : unit -> unit = "caml_avr_adc_init"
 external avr_analog_read : int -> int = "caml_avr_analog_read"
 
 
-let channel_of_pin : type a b c. (a register , b register, c register, yes analog_pin) pin -> int = function
+let channel_of_pin : type a b. (a register , yes analog_pin, b pwm_pin) pin -> int = function
   | PINA0 -> 0
   | PINA1 -> 1
   | PINA2 -> 2

--- a/avrs/arduino_mega_2560/avr.mli
+++ b/avrs/arduino_mega_2560/avr.mli
@@ -1,374 +1,139 @@
-type porta_bit = PA0 | PA1 | PA2 | PA3 | PA4 | PA5 | PA6 | PA7
-type portb_bit = PB0 | PB1 | PB2 | PB3 | PB4 | PB5 | PB6 | PB7
-type portc_bit = PC0 | PC1 | PC2 | PC3 | PC4 | PC5 | PC6 | PC7
-type portd_bit = PD0 | PD1 | PD2 | PD3 | PD4 | PD5 | PD6 | PD7
-type porte_bit = PE0 | PE1 | PE2 | PE3 | PE4 | PE5 | PE6 | PE7
-type portf_bit = PF0 | PF1 | PF2 | PF3 | PF4 | PF5 | PF6 | PF7
-type portg_bit = PG0 | PG1 | PG2 | PG3 | PG4 | PG5 | PG6 | PG7
-type porth_bit = PH0 | PH1 | PH2 | PH3 | PH4 | PH5 | PH6 | PH7
-type portj_bit = PJ0 | PJ1 | PJ2 | PJ3 | PJ4 | PJ5 | PJ6 | PJ7
-type portl_bit = PL0 | PL1 | PL2 | PL3 | PL4 | PL5 | PL6 | PL7
-type portk_bit = PK0 | PK1 | PK2 | PK3 | PK4 | PK5 | PK6 | PK7
-type ddra_bit = DA0 | DA1 | DA2 | DA3 | DA4 | DA5 | DA6 | DA7
-type ddrb_bit = DB0 | DB1 | DB2 | DB3 | DB4 | DB5 | DB6 | DB7
-type ddrc_bit = DC0 | DC1 | DC2 | DC3 | DC4 | DC5 | DC6 | DC7
-type ddrd_bit = DD0 | DD1 | DD2 | DD3 | DD4 | DD5 | DD6 | DD7
-type ddre_bit = DE0 | DE1 | DE2 | DE3 | DE4 | DE5 | DE6 | DE7
-type ddrf_bit = DF0 | DF1 | DF2 | DF3 | DF4 | DF5 | DF6 | DF7
-type ddrg_bit = DG0 | DG1 | DG2 | DG3 | DG4 | DG5 | DG6 | DG7
-type ddrh_bit = DH0 | DH1 | DH2 | DH3 | DH4 | DH5 | DH6 | DH7
-type ddrj_bit = DJ0 | DJ1 | DJ2 | DJ3 | DJ4 | DJ5 | DJ6 | DJ7
-type ddrl_bit = DL0 | DL1 | DL2 | DL3 | DL4 | DL5 | DL6 | DL7
-type ddrk_bit = DK0 | DK1 | DK2 | DK3 | DK4 | DK5 | DK6 | DK7
-type pina_bit = IA0 | IA1 | IA2 | IA3 | IA4 | IA5 | IA6 | IA7
-type pinb_bit = IB0 | IB1 | IB2 | IB3 | IB4 | IB5 | IB6 | IB7
-type pinc_bit = IC0 | IC1 | IC2 | IC3 | IC4 | IC5 | IC6 | IC7
-type pind_bit = ID0 | ID1 | ID2 | ID3 | ID4 | ID5 | ID6 | ID7
-type pine_bit = IE0 | IE1 | IE2 | IE3 | IE4 | IE5 | IE6 | IE7
-type pinf_bit = IF0 | IF1 | IF2 | IF3 | IF4 | IF5 | IF6 | IF7
-type ping_bit = IG0 | IG1 | IG2 | IG3 | IG4 | IG5 | IG6 | IG7
-type pinh_bit = IH0 | IH1 | IH2 | IH3 | IH4 | IH5 | IH6 | IH7
-type pinj_bit = IJ0 | IJ1 | IJ2 | IJ3 | IJ4 | IJ5 | IJ6 | IJ7
-type pinl_bit = IL0 | IL1 | IL2 | IL3 | IL4 | IL5 | IL6 | IL7
-type pink_bit = IK0 | IK1 | IK2 | IK3 | IK4 | IK5 | IK6 | IK7
+type a_bit = A0 | A1 | A2 | A3 | A4 | A5 | A6 | A7
+type b_bit = B0 | B1 | B2 | B3 | B4 | B5 | B6 | B7
+type c_bit = C0 | C1 | C2 | C3 | C4 | C5 | C6 | C7
+type d_bit = D0 | D1 | D2 | D3 | D4 | D5 | D6 | D7
+type e_bit = E0 | E1 | E2 | E3 | E4 | E5 | E6 | E7
+type f_bit = F0 | F1 | F2 | F3 | F4 | F5 | F6 | F7
+type g_bit = G0 | G1 | G2 | G3 | G4 | G5 | G6 | G7
+type h_bit = H0 | H1 | H2 | H3 | H4 | H5 | H6 | H7
+type j_bit = J0 | J1 | J2 | J3 | J4 | J5 | J6 | J7
+type l_bit = L0 | L1 | L2 | L3 | L4 | L5 | L6 | L7
+type k_bit = K0 | K1 | K2 | K3 | K4 | K5 | K6 | K7
 type spcr_bit = SPR0 | SPR1 | CPHA | CPOL | MSTR | DORD | SPE | SPIE
 type spsr_bit = SPI2x | SPSR1 | SPSR2 | SPSR3 | SPSR4 | SPSR5 | SPSR6 | SPIF
 type spdr_bit = SPDR0 | SPDR1 | SPDR2 | SPDR3 | SPDR4 | SPDR5 | SPDR6 | SPDR7
 type 'a register =
-    PORTA : porta_bit register
-  | PORTB : portb_bit register
-  | PORTC : portc_bit register
-  | PORTD : portd_bit register
-  | PORTE : porte_bit register
-  | PORTF : portf_bit register
-  | PORTG : portg_bit register
-  | PORTH : porth_bit register
-  | PORTJ : portj_bit register
-  | PORTK : portk_bit register
-  | PORTL : portl_bit register
-  | DDRA : ddra_bit register
-  | DDRB : ddrb_bit register
-  | DDRC : ddrc_bit register
-  | DDRD : ddrd_bit register
-  | DDRE : ddre_bit register
-  | DDRF : ddrf_bit register
-  | DDRG : ddrg_bit register
-  | DDRH : ddrh_bit register
-  | DDRJ : ddrj_bit register
-  | DDRK : ddrk_bit register
-  | DDRL : ddrl_bit register
-  | PINA : pina_bit register
-  | PINB : pinb_bit register
-  | PINC : pinc_bit register
-  | PIND : pind_bit register
-  | PINE : pine_bit register
-  | PINF : pinf_bit register
-  | PING : ping_bit register
-  | PINH : pinh_bit register
-  | PINJ : pinj_bit register
-  | PINK : pink_bit register
-  | PINL : pinl_bit register
+  | PORTA : a_bit register
+  | PORTB : b_bit register
+  | PORTC : c_bit register
+  | PORTD : d_bit register
+  | PORTE : e_bit register
+  | PORTF : f_bit register
+  | PORTG : g_bit register
+  | PORTH : h_bit register
+  | PORTJ : j_bit register
+  | PORTK : k_bit register
+  | PORTL : l_bit register
+  | DDRA : a_bit register
+  | DDRB : b_bit register
+  | DDRC : c_bit register
+  | DDRD : d_bit register
+  | DDRE : e_bit register
+  | DDRF : f_bit register
+  | DDRG : g_bit register
+  | DDRH : h_bit register
+  | DDRJ : j_bit register
+  | DDRK : k_bit register
+  | DDRL : l_bit register
+  | PINA : a_bit register
+  | PINB : b_bit register
+  | PINC : c_bit register
+  | PIND : d_bit register
+  | PINE : e_bit register
+  | PINF : f_bit register
+  | PING : g_bit register
+  | PINH : h_bit register
+  | PINJ : j_bit register
+  | PINK : k_bit register
+  | PINL : l_bit register
   | SPCR : spcr_bit register
   | SPSR : spsr_bit register
   | SPDR : spsr_bit register
 type yes
 type no
 type 'a analog_pin = YES : yes analog_pin | NO : no analog_pin
-type ('a, 'b, 'c, 'd) pin =
-    PIN0 :
-      (porte_bit register, ddre_bit register, pine_bit register,
-       no analog_pin)
-      pin
-  | PIN1 :
-      (porte_bit register, ddre_bit register, pine_bit register,
-       no analog_pin)
-      pin
-  | PIN2 :
-      (porte_bit register, ddre_bit register, pine_bit register,
-       no analog_pin)
-      pin
-  | PIN3 :
-      (porte_bit register, ddre_bit register, pine_bit register,
-       no analog_pin)
-      pin
-  | PIN4 :
-      (portg_bit register, ddrg_bit register, ping_bit register,
-       no analog_pin)
-      pin
-  | PIN5 :
-      (porte_bit register, ddre_bit register, pine_bit register,
-       no analog_pin)
-      pin
-  | PIN6 :
-      (porth_bit register, ddrh_bit register, pinh_bit register,
-       no analog_pin)
-      pin
-  | PIN7 :
-      (porth_bit register, ddrh_bit register, pinh_bit register,
-       no analog_pin)
-      pin
-  | PIN8 :
-      (porth_bit register, ddrh_bit register, pinh_bit register,
-       no analog_pin)
-      pin
-  | PIN9 :
-      (porth_bit register, ddrh_bit register, pinh_bit register,
-       no analog_pin)
-      pin
-  | PIN10 :
-      (portb_bit register, ddrb_bit register, pinb_bit register,
-       no analog_pin)
-      pin
-  | PIN11 :
-      (portb_bit register, ddrb_bit register, pinb_bit register,
-       no analog_pin)
-      pin
-  | PIN12 :
-      (portb_bit register, ddrb_bit register, pinb_bit register,
-       no analog_pin)
-      pin
-  | PIN13 :
-      (portb_bit register, ddrb_bit register, pinb_bit register,
-       no analog_pin)
-      pin
-  | PIN14 :
-      (portj_bit register, ddrj_bit register, pinj_bit register,
-       no analog_pin)
-      pin
-  | PIN15 :
-      (portj_bit register, ddrj_bit register, pinj_bit register,
-       no analog_pin)
-      pin
-  | PIN16 :
-      (porth_bit register, ddrh_bit register, pinh_bit register,
-       no analog_pin)
-      pin
-  | PIN17 :
-      (porth_bit register, ddrh_bit register, pinh_bit register,
-       no analog_pin)
-      pin
-  | PIN18 :
-      (portd_bit register, ddrd_bit register, pind_bit register,
-       no analog_pin)
-      pin
-  | PIN19 :
-      (portd_bit register, ddrd_bit register, pind_bit register,
-       no analog_pin)
-      pin
-  | PIN20 :
-      (portd_bit register, ddrd_bit register, pind_bit register,
-       no analog_pin)
-      pin
-  | PIN21 :
-      (portd_bit register, ddrd_bit register, pind_bit register,
-       no analog_pin)
-      pin
-  | PIN22 :
-      (porta_bit register, ddra_bit register, pina_bit register,
-       no analog_pin)
-      pin
-  | PIN23 :
-      (porta_bit register, ddra_bit register, pina_bit register,
-       no analog_pin)
-      pin
-  | PIN24 :
-      (porta_bit register, ddra_bit register, pina_bit register,
-       no analog_pin)
-      pin
-  | PIN25 :
-      (porta_bit register, ddra_bit register, pina_bit register,
-       no analog_pin)
-      pin
-  | PIN26 :
-      (porta_bit register, ddra_bit register, pina_bit register,
-       no analog_pin)
-      pin
-  | PIN27 :
-      (porta_bit register, ddra_bit register, pina_bit register,
-       no analog_pin)
-      pin
-  | PIN28 :
-      (porta_bit register, ddra_bit register, pina_bit register,
-       no analog_pin)
-      pin
-  | PIN29 :
-      (porta_bit register, ddra_bit register, pina_bit register,
-       no analog_pin)
-      pin
-  | PIN30 :
-      (portc_bit register, ddrc_bit register, pinc_bit register,
-       no analog_pin)
-      pin
-  | PIN31 :
-      (portc_bit register, ddrc_bit register, pinc_bit register,
-       no analog_pin)
-      pin
-  | PIN32 :
-      (portc_bit register, ddrc_bit register, pinc_bit register,
-       no analog_pin)
-      pin
-  | PIN33 :
-      (portc_bit register, ddrc_bit register, pinc_bit register,
-       no analog_pin)
-      pin
-  | PIN34 :
-      (portc_bit register, ddrc_bit register, pinc_bit register,
-       no analog_pin)
-      pin
-  | PIN35 :
-      (portc_bit register, ddrc_bit register, pinc_bit register,
-       no analog_pin)
-      pin
-  | PIN36 :
-      (portc_bit register, ddrc_bit register, pinc_bit register,
-       no analog_pin)
-      pin
-  | PIN37 :
-      (portc_bit register, ddrc_bit register, pinc_bit register,
-       no analog_pin)
-      pin
-  | PIN38 :
-      (portd_bit register, ddrd_bit register, pind_bit register,
-       no analog_pin)
-      pin
-  | PIN39 :
-      (portg_bit register, ddrg_bit register, ping_bit register,
-       no analog_pin)
-      pin
-  | PIN40 :
-      (portg_bit register, ddrg_bit register, ping_bit register,
-       no analog_pin)
-      pin
-  | PIN41 :
-      (portg_bit register, ddrg_bit register, ping_bit register,
-       no analog_pin)
-      pin
-  | PIN42 :
-      (portl_bit register, ddrl_bit register, pinl_bit register,
-       no analog_pin)
-      pin
-  | PIN43 :
-      (portl_bit register, ddrl_bit register, pinl_bit register,
-       no analog_pin)
-      pin
-  | PIN44 :
-      (portl_bit register, ddrl_bit register, pinl_bit register,
-       no analog_pin)
-      pin
-  | PIN45 :
-      (portl_bit register, ddrl_bit register, pinl_bit register,
-       no analog_pin)
-      pin
-  | PIN46 :
-      (portl_bit register, ddrl_bit register, pinl_bit register,
-       no analog_pin)
-      pin
-  | PIN47 :
-      (portl_bit register, ddrl_bit register, pinl_bit register,
-       no analog_pin)
-      pin
-  | PIN48 :
-      (portl_bit register, ddrl_bit register, pinl_bit register,
-       no analog_pin)
-      pin
-  | PIN49 :
-      (portl_bit register, ddrl_bit register, pinl_bit register,
-       no analog_pin)
-      pin
-  | MISO :
-      (portb_bit register, ddrb_bit register, pinb_bit register,
-       no analog_pin)
-      pin
-  | SCK :
-      (portb_bit register, ddrb_bit register, pinb_bit register,
-       no analog_pin)
-      pin
-  | MOSI :
-      (portb_bit register, ddrb_bit register, pinb_bit register,
-       no analog_pin)
-      pin
-  | SS :
-      (portb_bit register, ddrb_bit register, pinb_bit register,
-       no analog_pin)
-      pin
-  | PINA0 :
-      (portf_bit register, ddrf_bit register, pinf_bit register,
-       yes analog_pin)
-      pin
-  | PINA1 :
-      (portf_bit register, ddrf_bit register, pinf_bit register,
-       yes analog_pin)
-      pin
-  | PINA2 :
-      (portf_bit register, ddrf_bit register, pinf_bit register,
-       yes analog_pin)
-      pin
-  | PINA3 :
-      (portf_bit register, ddrf_bit register, pinf_bit register,
-       yes analog_pin)
-      pin
-  | PINA4 :
-      (portf_bit register, ddrf_bit register, pinf_bit register,
-       yes analog_pin)
-      pin
-  | PINA5 :
-      (portf_bit register, ddrf_bit register, pinf_bit register,
-       yes analog_pin)
-      pin
-  | PINA6 :
-      (portf_bit register, ddrf_bit register, pinf_bit register,
-       yes analog_pin)
-      pin
-  | PINA7 :
-      (portf_bit register, ddrf_bit register, pinf_bit register,
-       yes analog_pin)
-      pin
-  | PINA8 :
-      (portk_bit register, ddrk_bit register, pink_bit register,
-       yes analog_pin)
-      pin
-  | PINA9 :
-      (portk_bit register, ddrk_bit register, pink_bit register,
-       yes analog_pin)
-      pin
-  | PINA10 :
-      (portk_bit register, ddrk_bit register, pink_bit register,
-       yes analog_pin)
-      pin
-  | PINA11 :
-      (portk_bit register, ddrk_bit register, pink_bit register,
-       yes analog_pin)
-      pin
-  | PINA12 :
-      (portk_bit register, ddrk_bit register, pink_bit register,
-       yes analog_pin)
-      pin
-  | PINA13 :
-      (portk_bit register, ddrk_bit register, pink_bit register,
-       yes analog_pin)
-      pin
-  | PINA14 :
-      (portk_bit register, ddrk_bit register, pink_bit register,
-       yes analog_pin)
-      pin
-  | PINA15 :
-      (portk_bit register, ddrk_bit register, pink_bit register,
-       yes analog_pin)
-      pin
+type 'a pwm_pin = YES : yes pwm_pin | NO : no pwm_pin
+type ('a,'b,'c) pin =
+  | PIN0  : (e_bit register, no analog_pin, no pwm_pin) pin
+  | PIN1  : (e_bit register, no analog_pin, no pwm_pin) pin
+  | PIN2  : (e_bit register, no analog_pin, yes pwm_pin) pin
+  | PIN3  : (e_bit register, no analog_pin, yes pwm_pin) pin
+  | PIN4  : (g_bit register, no analog_pin, yes pwm_pin) pin
+  | PIN5  : (e_bit register, no analog_pin, yes pwm_pin) pin
+  | PIN6  : (h_bit register, no analog_pin, yes pwm_pin) pin
+  | PIN7  : (h_bit register, no analog_pin, yes pwm_pin) pin
+  | PIN8  : (h_bit register, no analog_pin, yes pwm_pin) pin
+  | PIN9  : (h_bit register, no analog_pin, yes pwm_pin) pin
+  | PIN10 : (b_bit register, no analog_pin, yes pwm_pin) pin
+  | PIN11 : (b_bit register, no analog_pin, yes pwm_pin) pin
+  | PIN12 : (b_bit register, no analog_pin, yes pwm_pin) pin
+  | PIN13 : (b_bit register, no analog_pin, yes pwm_pin) pin
+  | PIN14 : (j_bit register, no analog_pin, no pwm_pin) pin
+  | PIN15 : (j_bit register, no analog_pin, no pwm_pin) pin
+  | PIN16 : (h_bit register, no analog_pin, no pwm_pin) pin
+  | PIN17 : (h_bit register, no analog_pin, no pwm_pin) pin
+  | PIN18 : (d_bit register, no analog_pin, no pwm_pin) pin
+  | PIN19 : (d_bit register, no analog_pin, no pwm_pin) pin
+  | PIN20 : (d_bit register, no analog_pin, no pwm_pin) pin
+  | PIN21 : (d_bit register, no analog_pin, no pwm_pin) pin
+  | PIN22 : (a_bit register, no analog_pin, no pwm_pin) pin
+  | PIN23 : (a_bit register, no analog_pin, no pwm_pin) pin
+  | PIN24 : (a_bit register, no analog_pin, no pwm_pin) pin
+  | PIN25 : (a_bit register, no analog_pin, no pwm_pin) pin
+  | PIN26 : (a_bit register, no analog_pin, no pwm_pin) pin
+  | PIN27 : (a_bit register, no analog_pin, no pwm_pin) pin
+  | PIN28 : (a_bit register, no analog_pin, no pwm_pin) pin
+  | PIN29 : (a_bit register, no analog_pin, no pwm_pin) pin
+  | PIN30 : (c_bit register, no analog_pin, no pwm_pin) pin
+  | PIN31 : (c_bit register, no analog_pin, no pwm_pin) pin
+  | PIN32 : (c_bit register, no analog_pin, no pwm_pin) pin
+  | PIN33 : (c_bit register, no analog_pin, no pwm_pin) pin
+  | PIN34 : (c_bit register, no analog_pin, no pwm_pin) pin
+  | PIN35 : (c_bit register, no analog_pin, no pwm_pin) pin
+  | PIN36 : (c_bit register, no analog_pin, no pwm_pin) pin
+  | PIN37 : (c_bit register, no analog_pin, no pwm_pin) pin
+  | PIN38 : (d_bit register, no analog_pin, no pwm_pin) pin
+  | PIN39 : (g_bit register, no analog_pin, no pwm_pin) pin
+  | PIN40 : (g_bit register, no analog_pin, no pwm_pin) pin
+  | PIN41 : (g_bit register, no analog_pin, no pwm_pin) pin
+  | PIN42 : (l_bit register, no analog_pin, no pwm_pin) pin
+  | PIN43 : (l_bit register, no analog_pin, no pwm_pin) pin
+  | PIN44 : (l_bit register, no analog_pin, yes pwm_pin) pin
+  | PIN45 : (l_bit register, no analog_pin, yes pwm_pin) pin
+  | PIN46 : (l_bit register, no analog_pin, yes pwm_pin) pin
+  | PIN47 : (l_bit register, no analog_pin, no pwm_pin) pin
+  | PIN48 : (l_bit register, no analog_pin, no pwm_pin) pin
+  | PIN49 : (l_bit register, no analog_pin, no pwm_pin) pin
+  | MISO  : (b_bit register, no analog_pin, no pwm_pin) pin
+  | SCK   : (b_bit register, no analog_pin, no pwm_pin) pin
+  | MOSI  : (b_bit register, no analog_pin, no pwm_pin) pin
+  | SS    : (b_bit register, no analog_pin, no pwm_pin) pin
+  | PINA0 : (f_bit register, yes analog_pin, no pwm_pin) pin
+  | PINA1 : (f_bit register, yes analog_pin, no pwm_pin) pin
+  | PINA2 : (f_bit register, yes analog_pin, no pwm_pin) pin
+  | PINA3 : (f_bit register, yes analog_pin, no pwm_pin) pin
+  | PINA4 : (f_bit register, yes analog_pin, no pwm_pin) pin
+  | PINA5 : (f_bit register, yes analog_pin, no pwm_pin) pin
+  | PINA6 : (f_bit register, yes analog_pin, no pwm_pin) pin
+  | PINA7 : (f_bit register, yes analog_pin, no pwm_pin) pin
+  | PINA8 : (k_bit register, yes analog_pin, no pwm_pin) pin
+  | PINA9 : (k_bit register, yes analog_pin, no pwm_pin) pin
+  | PINA10 : (k_bit register, yes analog_pin, no pwm_pin) pin
+  | PINA11 : (k_bit register, yes analog_pin, no pwm_pin) pin
+  | PINA12 : (k_bit register, yes analog_pin, no pwm_pin) pin
+  | PINA13 : (k_bit register, yes analog_pin, no pwm_pin) pin
+  | PINA14 : (k_bit register, yes analog_pin, no pwm_pin) pin
+  | PINA15 : (k_bit register, yes analog_pin, no pwm_pin) pin
 type mode = INPUT | OUTPUT | INPUT_PULLUP
 type level = LOW | HIGH
 val port_of_pin :
-  ('a register, 'b register, 'c register, 'd analog_pin) pin -> 'a register
+  ('a register, 'b analog_pin, 'c pwm_pin) pin -> 'a register
 val ddr_of_pin :
-  ('a register, 'b register, 'c register, 'd analog_pin) pin -> 'b register
+  ('a register, 'b analog_pin, 'c pwm_pin) pin -> 'a register
 val input_of_pin :
-  ('a register, 'b register, 'c register, 'd analog_pin) pin -> 'c register
-val port_bit_of_pin :
-  ('a register, 'b register, 'c register, 'd analog_pin) pin -> 'a
-val ddr_bit_of_pin :
-  ('a register, 'b register, 'c register, 'd analog_pin) pin -> 'b
-val input_bit_of_pin :
-  ('a register, 'b register, 'c register, 'd analog_pin) pin -> 'c
+  ('a register, 'b analog_pin, 'c pwm_pin) pin -> 'a register
+val bit_of_pin :
+  ('a register, 'b analog_pin, 'c pwm_pin) pin -> 'a
 external write_register : 'a register -> int -> unit
   = "caml_avr_write_register" [@@noalloc]
 external read_register : 'a register -> int = "caml_avr_read_register"
@@ -383,17 +148,17 @@ external millis : unit -> int = "caml_avr_millis" [@@noalloc]
 val bool_of_level : level -> bool
 val level_of_bool : bool -> level
 val pin_mode :
-  ('a register, 'b register, 'c register, 'd analog_pin) pin -> mode -> unit
+  ('a register, 'b analog_pin, 'c pwm_pin) pin -> mode -> unit
 val digital_write :
-  ('a register, 'b register, 'c register, 'd analog_pin) pin -> level -> unit
+  ('a register, 'b analog_pin, 'c pwm_pin) pin -> level -> unit
 val digital_read :
-  ('a register, 'b register, 'c register, 'd analog_pin) pin -> level
+  ('a register, 'b analog_pin, 'c pwm_pin) pin -> level
 external adc_init : unit -> unit = "caml_avr_adc_init"
 external avr_analog_read : int -> int = "caml_avr_analog_read"
 val channel_of_pin :
-  ('a register, 'b register, 'c register, yes analog_pin) pin -> int
+  ('a register, yes analog_pin, 'b pwm_pin) pin -> int
 val analog_read :
-  ('a register, 'b register, 'c register, yes analog_pin) pin -> int
+  ('a register, yes analog_pin, 'b pwm_pin) pin -> int
 module Serial :
   sig
     external init : unit -> unit = "caml_avr_serial_init" [@@noalloc]

--- a/avrs/arduino_uno/avr.ml
+++ b/avrs/arduino_uno/avr.ml
@@ -1,71 +1,65 @@
-type portb_bit = PB0 | PB1 | PB2 | PB3 | PB4 | PB5 | PB6 | PB7
-type portc_bit = PC0 | PC1 | PC2 | PC3 | PC4 | PC5 | PC6 | PC7
-type portd_bit = PD0 | PD1 | PD2 | PD3 | PD4 | PD5 | PD6 | PD7
-
-type ddrb_bit = DB0 | DB1 | DB2 | DB3 | DB4 | DB5 | DB6 | DB7
-type ddrc_bit = DC0 | DC1 | DC2 | DC3 | DC4 | DC5 | DC6 | DC7
-type ddrd_bit = DD0 | DD1 | DD2 | DD3 | DD4 | DD5 | DD6 | DD7
-
-type pinb_bit = IB0 | IB1 | IB2 | IB3 | IB4 | IB5 | IB6 | IB7
-type pinc_bit = IC0 | IC1 | IC2 | IC3 | IC4 | IC5 | IC6 | IC7
-type pind_bit = ID0 | ID1 | ID2 | ID3 | ID4 | ID5 | ID6 | ID7
+type b_bit = B0 | B1 | B2 | B3 | B4 | B5 | B6 | B7
+type c_bit = C0 | C1 | C2 | C3 | C4 | C5 | C6 | C7
+type d_bit = D0 | D1 | D2 | D3 | D4 | D5 | D6 | D7
 
 type spcr_bit = SPR0 | SPR1 | CPHA | CPOL | MSTR | DORD | SPE | SPIE
 type spsr_bit = SPI2x | SPSR1 | SPSR2 | SPSR3 | SPSR4 | SPSR5 | SPSR6 | SPIF
 type spdr_bit = SPDR0 | SPDR1 | SPDR2 | SPDR3 | SPDR4 | SPDR5 | SPDR6 | SPDR7
 
 type 'a register =
-  | PORTB : portb_bit register
-  | PORTC : portc_bit register
-  | PORTD : portd_bit register
-  | DDRB : ddrb_bit register
-  | DDRC : ddrc_bit register
-  | DDRD : ddrd_bit register
-  | PINB : pinb_bit register
-  | PINC : pinc_bit register
-  | PIND : pind_bit register
+  | PORTB : b_bit register
+  | PORTC : c_bit register
+  | PORTD : d_bit register
+  | DDRB : b_bit register
+  | DDRC : c_bit register
+  | DDRD : d_bit register
+  | PINB : b_bit register
+  | PINC : c_bit register
+  | PIND : d_bit register
   | SPCR : spcr_bit register
   | SPSR : spsr_bit register
-  | SPDR : spsr_bit register
+  | SPDR : spdr_bit register
 
 type yes
 type no
 type 'a analog_pin =
   | YES : yes analog_pin
   | NO : no analog_pin
+type 'a pwm_pin =
+  | YES : yes pwm_pin
+  | NO : no pwm_pin
 
-
-type ('a,'b,'c,'d) pin =
-  | PIN0  : (portd_bit register, ddrd_bit register, pind_bit register, no analog_pin) pin
-  | PIN1  : (portd_bit register, ddrd_bit register, pind_bit register, no analog_pin) pin
-  | PIN2  : (portd_bit register, ddrd_bit register, pind_bit register, no analog_pin) pin
-  | PIN3  : (portd_bit register, ddrd_bit register, pind_bit register, no analog_pin) pin
-  | PIN4  : (portd_bit register, ddrd_bit register, pind_bit register, no analog_pin) pin
-  | PIN5  : (portd_bit register, ddrd_bit register, pind_bit register, no analog_pin) pin
-  | PIN6  : (portd_bit register, ddrd_bit register, pind_bit register, no analog_pin) pin
-  | PIN7  : (portd_bit register, ddrd_bit register, pind_bit register, no analog_pin) pin
-  | PIN8  : (portb_bit register, ddrb_bit register, pinb_bit register, no analog_pin) pin
-  | PIN9  : (portb_bit register, ddrb_bit register, pinb_bit register, no analog_pin) pin
-  | PIN10 : (portb_bit register, ddrb_bit register, pinb_bit register, no analog_pin) pin
-  | PIN11 : (portb_bit register, ddrb_bit register, pinb_bit register, no analog_pin) pin
-  | PIN12 : (portb_bit register, ddrb_bit register, pinb_bit register, no analog_pin) pin
-  | PIN13 : (portb_bit register, ddrb_bit register, pinb_bit register, no analog_pin) pin
-  | MISO  : (portb_bit register, ddrb_bit register, pinb_bit register, no analog_pin) pin
-  | SCK   : (portb_bit register, ddrb_bit register, pinb_bit register, no analog_pin) pin
-  | MOSI  : (portb_bit register, ddrb_bit register, pinb_bit register, no analog_pin) pin
-  | SS    : (portb_bit register, ddrb_bit register, pinb_bit register, no analog_pin) pin
-  | PINA0 : (portc_bit register, ddrc_bit register, pinc_bit register, yes analog_pin) pin
-  | PINA1 : (portc_bit register, ddrc_bit register, pinc_bit register, yes analog_pin) pin
-  | PINA2 : (portc_bit register, ddrc_bit register, pinc_bit register, yes analog_pin) pin
-  | PINA3 : (portc_bit register, ddrc_bit register, pinc_bit register, yes analog_pin) pin
-  | PINA4 : (portc_bit register, ddrc_bit register, pinc_bit register, yes analog_pin) pin
-  | PINA5 : (portc_bit register, ddrc_bit register, pinc_bit register, yes analog_pin) pin
+type ('a,'b,'c) pin =
+  | PIN0  : (d_bit register, no analog_pin, no pwm_pin) pin
+  | PIN1  : (d_bit register, no analog_pin, no pwm_pin) pin
+  | PIN2  : (d_bit register, no analog_pin, no pwm_pin) pin
+  | PIN3  : (d_bit register, no analog_pin, yes pwm_pin) pin
+  | PIN4  : (d_bit register, no analog_pin, no pwm_pin) pin
+  | PIN5  : (d_bit register, no analog_pin, yes pwm_pin) pin
+  | PIN6  : (d_bit register, no analog_pin, yes pwm_pin) pin
+  | PIN7  : (d_bit register, no analog_pin, no pwm_pin) pin
+  | PIN8  : (b_bit register, no analog_pin, no pwm_pin) pin
+  | PIN9  : (b_bit register, no analog_pin, yes pwm_pin) pin
+  | PIN10 : (b_bit register, no analog_pin, yes pwm_pin) pin
+  | PIN11 : (b_bit register, no analog_pin, yes pwm_pin) pin
+  | PIN12 : (b_bit register, no analog_pin, no pwm_pin) pin
+  | PIN13 : (b_bit register, no analog_pin, no pwm_pin) pin
+  | MISO  : (b_bit register, no analog_pin, no pwm_pin) pin
+  | SCK   : (b_bit register, no analog_pin, no pwm_pin) pin
+  | MOSI  : (b_bit register, no analog_pin, no pwm_pin) pin
+  | SS    : (b_bit register, no analog_pin, no pwm_pin) pin
+  | PINA0 : (c_bit register, yes analog_pin, no pwm_pin) pin
+  | PINA1 : (c_bit register, yes analog_pin, no pwm_pin) pin
+  | PINA2 : (c_bit register, yes analog_pin, no pwm_pin) pin
+  | PINA3 : (c_bit register, yes analog_pin, no pwm_pin) pin
+  | PINA4 : (c_bit register, yes analog_pin, no pwm_pin) pin
+  | PINA5 : (c_bit register, yes analog_pin, no pwm_pin) pin
 
 type mode = INPUT | OUTPUT | INPUT_PULLUP
 
 type level = LOW | HIGH
 
-let port_of_pin : type a b c d. (a register, b register, c register,d analog_pin) pin -> a register =
+let port_of_pin : type a b c. (a register, b analog_pin, c pwm_pin) pin -> a register =
   function
   | PIN0 -> PORTD
   | PIN1 -> PORTD
@@ -92,7 +86,7 @@ let port_of_pin : type a b c d. (a register, b register, c register,d analog_pin
   | PINA4 -> PORTC
   | PINA5 -> PORTC
 
-let ddr_of_pin : type a b c d. (a register , b register, c register, d analog_pin) pin -> b register=
+let ddr_of_pin : type a b c. (a register , b analog_pin, c pwm_pin) pin -> a register=
   function
   | PIN0 -> DDRD
   | PIN1 -> DDRD
@@ -120,7 +114,7 @@ let ddr_of_pin : type a b c d. (a register , b register, c register, d analog_pi
   | PINA5 -> DDRC
 
 
-let input_of_pin : type a b c d. (a register , b register, c register, d analog_pin) pin -> c register=
+let input_of_pin : type a b c. (a register , b analog_pin, c pwm_pin) pin -> a register=
   function
   | PIN0 -> PIND
   | PIN1 -> PIND
@@ -147,89 +141,32 @@ let input_of_pin : type a b c d. (a register , b register, c register, d analog_
   | PINA4 -> PINC
   | PINA5 -> PINC
 
-let port_bit_of_pin : type a b c d. (a register, b register, c register, d analog_pin) pin -> a =
+let bit_of_pin : type a b c. (a register, b analog_pin, c pwm_pin) pin -> a =
   function
-  | PIN0 -> PD0
-  | PIN1 -> PD1
-  | PIN2 -> PD2
-  | PIN3 -> PD3
-  | PIN4 -> PD4
-  | PIN5 -> PD5
-  | PIN6 -> PD6
-  | PIN7 -> PD7
-  | PIN8 -> PB0
-  | PIN9 -> PB1
-  | PIN10 -> PB2
-  | PIN11 -> PB3
-  | PIN12 -> PB4
-  | PIN13 -> PB5
-  | MISO -> PB4
-  | SCK -> PB5
-  | MOSI -> PB3
-  | SS -> PB0
-  | PINA0 -> PC0
-  | PINA1 -> PC1
-  | PINA2 -> PC2
-  | PINA3 -> PC3
-  | PINA4 -> PC4
-  | PINA5 -> PC5
-
-
-let ddr_bit_of_pin : type a b c d. (a register, b register, c register, d analog_pin) pin -> b =
-  function
-  | PIN0 -> DD0
-  | PIN1 -> DD1
-  | PIN2 -> DD2
-  | PIN3 -> DD3
-  | PIN4 -> DD4
-  | PIN5 -> DD5
-  | PIN6 -> DD6
-  | PIN7 -> DD7
-  | PIN8 -> DB0
-  | PIN9 -> DB1
-  | PIN10 -> DB2
-  | PIN11 -> DB3
-  | PIN12 -> DB4
-  | PIN13 -> DB5
-  | MISO -> DB4
-  | SCK -> DB5
-  | MOSI -> DB3
-  | SS -> DB0
-  | PINA0 -> DC0
-  | PINA1 -> DC1
-  | PINA2 -> DC2
-  | PINA3 -> DC3
-  | PINA4 -> DC4
-  | PINA5 -> DC5
-
-
-let input_bit_of_pin : type a b c d . (a register, b register, c register, d analog_pin) pin -> c =
-  function
-  | PIN0 -> ID0
-  | PIN1 -> ID1
-  | PIN2 -> ID2
-  | PIN3 -> ID3
-  | PIN4 -> ID4
-  | PIN5 -> ID5
-  | PIN6 -> ID6
-  | PIN7 -> ID7
-  | PIN8 -> IB0
-  | PIN9 -> IB1
-  | PIN10 -> IB2
-  | PIN11 -> IB3
-  | PIN12 -> IB4
-  | PIN13 -> IB5
-  | MISO -> IB4
-  | SCK -> IB5
-  | MOSI -> IB3
-  | SS -> IB0
-  | PINA0 -> IC0
-  | PINA1 -> IC1
-  | PINA2 -> IC2
-  | PINA3 -> IC3
-  | PINA4 -> IC4
-  | PINA5 -> IC5
-
+  | PIN0 -> D0
+  | PIN1 -> D1
+  | PIN2 -> D2
+  | PIN3 -> D3
+  | PIN4 -> D4
+  | PIN5 -> D5
+  | PIN6 -> D6
+  | PIN7 -> D7
+  | PIN8 -> B0
+  | PIN9 -> B1
+  | PIN10 -> B2
+  | PIN11 -> B3
+  | PIN12 -> B4
+  | PIN13 -> B5
+  | MISO -> B4
+  | SCK -> B5
+  | MOSI -> B3
+  | SS -> B0
+  | PINA0 -> C0
+  | PINA1 -> C1
+  | PINA2 -> C2
+  | PINA3 -> C3
+  | PINA4 -> C4
+  | PINA5 -> C5
 
 external write_register : 'a register -> int -> unit = "caml_avr_write_register" [@@noalloc]
 external read_register : 'a register -> int = "caml_avr_read_register" [@@noalloc]
@@ -245,29 +182,28 @@ let level_of_bool = function false -> LOW | true -> HIGH
 
 let pin_mode p m =
   let port = port_of_pin p in
-  let bit = port_bit_of_pin p in
-  let ddr_bit = ddr_bit_of_pin p in
+  let bit = bit_of_pin p in
   let ddr = ddr_of_pin p in
   match m with
   | OUTPUT ->
-    set_bit ddr ddr_bit
+    set_bit ddr bit
   | INPUT ->
-    clear_bit ddr ddr_bit;
+    clear_bit ddr bit;
     clear_bit port bit
   | INPUT_PULLUP ->
-    clear_bit ddr ddr_bit;
+    clear_bit ddr bit;
     set_bit port bit
 
 let digital_write p b =
   let port = port_of_pin p in
-  let bit = port_bit_of_pin p in
+  let bit = bit_of_pin p in
   match b with
   | HIGH -> set_bit port bit
   | LOW -> clear_bit port bit
 
 let digital_read p =
   let input = input_of_pin p in
-  let ibit = input_bit_of_pin p in
+  let ibit = bit_of_pin p in
   match read_bit input ibit with
   | true -> HIGH
   | false -> LOW

--- a/avrs/arduino_uno/avr.mli
+++ b/avrs/arduino_uno/avr.mli
@@ -1,142 +1,61 @@
-type portb_bit = PB0 | PB1 | PB2 | PB3 | PB4 | PB5 | PB6 | PB7
-type portc_bit = PC0 | PC1 | PC2 | PC3 | PC4 | PC5 | PC6 | PC7
-type portd_bit = PD0 | PD1 | PD2 | PD3 | PD4 | PD5 | PD6 | PD7
-type ddrb_bit = DB0 | DB1 | DB2 | DB3 | DB4 | DB5 | DB6 | DB7
-type ddrc_bit = DC0 | DC1 | DC2 | DC3 | DC4 | DC5 | DC6 | DC7
-type ddrd_bit = DD0 | DD1 | DD2 | DD3 | DD4 | DD5 | DD6 | DD7
-type pinb_bit = IB0 | IB1 | IB2 | IB3 | IB4 | IB5 | IB6 | IB7
-type pinc_bit = IC0 | IC1 | IC2 | IC3 | IC4 | IC5 | IC6 | IC7
-type pind_bit = ID0 | ID1 | ID2 | ID3 | ID4 | ID5 | ID6 | ID7
+type b_bit = B0 | B1 | B2 | B3 | B4 | B5 | B6 | B7
+type c_bit = C0 | C1 | C2 | C3 | C4 | C5 | C6 | C7
+type d_bit = D0 | D1 | D2 | D3 | D4 | D5 | D6 | D7
 type spcr_bit = SPR0 | SPR1 | CPHA | CPOL | MSTR | DORD | SPE | SPIE
 type spsr_bit = SPI2x | SPSR1 | SPSR2 | SPSR3 | SPSR4 | SPSR5 | SPSR6 | SPIF
 type spdr_bit = SPDR0 | SPDR1 | SPDR2 | SPDR3 | SPDR4 | SPDR5 | SPDR6 | SPDR7
 type 'a register =
-    PORTB : portb_bit register
-  | PORTC : portc_bit register
-  | PORTD : portd_bit register
-  | DDRB : ddrb_bit register
-  | DDRC : ddrc_bit register
-  | DDRD : ddrd_bit register
-  | PINB : pinb_bit register
-  | PINC : pinc_bit register
-  | PIND : pind_bit register
+    PORTB : b_bit register
+  | PORTC : c_bit register
+  | PORTD : d_bit register
+  | DDRB : b_bit register
+  | DDRC : c_bit register
+  | DDRD : d_bit register
+  | PINB : b_bit register
+  | PINC : c_bit register
+  | PIND : d_bit register
   | SPCR : spcr_bit register
   | SPSR : spsr_bit register
-  | SPDR : spsr_bit register
+  | SPDR : spdr_bit register
 type yes
 type no
 type 'a analog_pin = YES : yes analog_pin | NO : no analog_pin
-type ('a, 'b, 'c, 'd) pin =
-    PIN0 :
-      (portd_bit register, ddrd_bit register, pind_bit register,
-       no analog_pin)
-      pin
-  | PIN1 :
-      (portd_bit register, ddrd_bit register, pind_bit register,
-       no analog_pin)
-      pin
-  | PIN2 :
-      (portd_bit register, ddrd_bit register, pind_bit register,
-       no analog_pin)
-      pin
-  | PIN3 :
-      (portd_bit register, ddrd_bit register, pind_bit register,
-       no analog_pin)
-      pin
-  | PIN4 :
-      (portd_bit register, ddrd_bit register, pind_bit register,
-       no analog_pin)
-      pin
-  | PIN5 :
-      (portd_bit register, ddrd_bit register, pind_bit register,
-       no analog_pin)
-      pin
-  | PIN6 :
-      (portd_bit register, ddrd_bit register, pind_bit register,
-       no analog_pin)
-      pin
-  | PIN7 :
-      (portd_bit register, ddrd_bit register, pind_bit register,
-       no analog_pin)
-      pin
-  | PIN8 :
-      (portb_bit register, ddrb_bit register, pinb_bit register,
-       no analog_pin)
-      pin
-  | PIN9 :
-      (portb_bit register, ddrb_bit register, pinb_bit register,
-       no analog_pin)
-      pin
-  | PIN10 :
-      (portb_bit register, ddrb_bit register, pinb_bit register,
-       no analog_pin)
-      pin
-  | PIN11 :
-      (portb_bit register, ddrb_bit register, pinb_bit register,
-       no analog_pin)
-      pin
-  | PIN12 :
-      (portb_bit register, ddrb_bit register, pinb_bit register,
-       no analog_pin)
-      pin
-  | PIN13 :
-      (portb_bit register, ddrb_bit register, pinb_bit register,
-       no analog_pin)
-      pin
-  | MISO :
-      (portb_bit register, ddrb_bit register, pinb_bit register,
-       no analog_pin)
-      pin
-  | SCK :
-      (portb_bit register, ddrb_bit register, pinb_bit register,
-       no analog_pin)
-      pin
-  | MOSI :
-      (portb_bit register, ddrb_bit register, pinb_bit register,
-       no analog_pin)
-      pin
-  | SS :
-      (portb_bit register, ddrb_bit register, pinb_bit register,
-       no analog_pin)
-      pin
-  | PINA0 :
-      (portc_bit register, ddrc_bit register, pinc_bit register,
-       yes analog_pin)
-      pin
-  | PINA1 :
-      (portc_bit register, ddrc_bit register, pinc_bit register,
-       yes analog_pin)
-      pin
-  | PINA2 :
-      (portc_bit register, ddrc_bit register, pinc_bit register,
-       yes analog_pin)
-      pin
-  | PINA3 :
-      (portc_bit register, ddrc_bit register, pinc_bit register,
-       yes analog_pin)
-      pin
-  | PINA4 :
-      (portc_bit register, ddrc_bit register, pinc_bit register,
-       yes analog_pin)
-      pin
-  | PINA5 :
-      (portc_bit register, ddrc_bit register, pinc_bit register,
-       yes analog_pin)
-      pin
+type 'a pwm_pin = YES : yes pwm_pin | NO : no pwm_pin
+type ('a,'b,'c) pin =
+  | PIN0  : (d_bit register, no analog_pin, no pwm_pin) pin
+  | PIN1  : (d_bit register, no analog_pin, no pwm_pin) pin
+  | PIN2  : (d_bit register, no analog_pin, no pwm_pin) pin
+  | PIN3  : (d_bit register, no analog_pin, yes pwm_pin) pin
+  | PIN4  : (d_bit register, no analog_pin, no pwm_pin) pin
+  | PIN5  : (d_bit register, no analog_pin, yes pwm_pin) pin
+  | PIN6  : (d_bit register, no analog_pin, yes pwm_pin) pin
+  | PIN7  : (d_bit register, no analog_pin, no pwm_pin) pin
+  | PIN8  : (b_bit register, no analog_pin, no pwm_pin) pin
+  | PIN9  : (b_bit register, no analog_pin, yes pwm_pin) pin
+  | PIN10 : (b_bit register, no analog_pin, yes pwm_pin) pin
+  | PIN11 : (b_bit register, no analog_pin, yes pwm_pin) pin
+  | PIN12 : (b_bit register, no analog_pin, no pwm_pin) pin
+  | PIN13 : (b_bit register, no analog_pin, no pwm_pin) pin
+  | MISO  : (b_bit register, no analog_pin, no pwm_pin) pin
+  | SCK   : (b_bit register, no analog_pin, no pwm_pin) pin
+  | MOSI  : (b_bit register, no analog_pin, no pwm_pin) pin
+  | SS    : (b_bit register, no analog_pin, no pwm_pin) pin
+  | PINA0 : (c_bit register, yes analog_pin, no pwm_pin) pin
+  | PINA1 : (c_bit register, yes analog_pin, no pwm_pin) pin
+  | PINA2 : (c_bit register, yes analog_pin, no pwm_pin) pin
+  | PINA3 : (c_bit register, yes analog_pin, no pwm_pin) pin
+  | PINA4 : (c_bit register, yes analog_pin, no pwm_pin) pin
+  | PINA5 : (c_bit register, yes analog_pin, no pwm_pin) pin
 type mode = INPUT | OUTPUT | INPUT_PULLUP
 type level = LOW | HIGH
 val port_of_pin :
-  ('a register, 'b register, 'c register, 'd analog_pin) pin -> 'a register
+  ('a register, 'b analog_pin, 'c pwm_pin) pin -> 'a register
 val ddr_of_pin :
-  ('a register, 'b register, 'c register, 'd analog_pin) pin -> 'b register
+  ('a register, 'b analog_pin, 'c pwm_pin) pin -> 'a register
 val input_of_pin :
-  ('a register, 'b register, 'c register, 'd analog_pin) pin -> 'c register
-val port_bit_of_pin :
-  ('a register, 'b register, 'c register, 'd analog_pin) pin -> 'a
-val ddr_bit_of_pin :
-  ('a register, 'b register, 'c register, 'd analog_pin) pin -> 'b
-val input_bit_of_pin :
-  ('a register, 'b register, 'c register, 'd analog_pin) pin -> 'c
+  ('a register, 'b analog_pin, 'c pwm_pin) pin -> 'a register
+val bit_of_pin :
+  ('a register, 'b analog_pin, 'c pwm_pin) pin -> 'a
 external write_register : 'a register -> int -> unit
   = "caml_avr_write_register" [@@noalloc]
 external read_register : 'a register -> int = "caml_avr_read_register"
@@ -151,11 +70,11 @@ external millis : unit -> int = "caml_avr_millis" [@@noalloc]
 val bool_of_level : level -> bool
 val level_of_bool : bool -> level
 val pin_mode :
-  ('a register, 'b register, 'c register, 'd analog_pin) pin -> mode -> unit
+  ('a register, 'b analog_pin, 'c pwm_pin) pin -> mode -> unit
 val digital_write :
-  ('a register, 'b register, 'c register, 'd analog_pin) pin -> level -> unit
+  ('a register, 'b analog_pin, 'c pwm_pin) pin -> level -> unit
 val digital_read :
-  ('a register, 'b register, 'c register, 'd analog_pin) pin -> level
+  ('a register, 'b analog_pin, 'c pwm_pin) pin -> level
 module Serial :
   sig
     external init : unit -> unit = "caml_avr_serial_init" [@@noalloc]

--- a/src/stdlib/liquidCrystal.ml
+++ b/src/stdlib/liquidCrystal.ml
@@ -45,9 +45,9 @@ and lcd_2line = 0x08 and lcd_1line = 0x00
 
 type ('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i) lcd = {
   is4bitmode : bool;
-  rsPin : ('a register, 'b register, 'c register, no analog_pin) pin;
-  enablePin : ('d register, 'e register, 'f register, no analog_pin) pin;
-  dpins : ('g register, 'h register, 'i register, no analog_pin) pin array;
+  rsPin : ('a register, 'b analog_pin, 'c pwm_pin) pin;
+  enablePin : ('d register, 'e analog_pin, 'f pwm_pin) pin;
+  dpins : ('g register, 'h analog_pin, 'i pwm_pin) pin array;
   mutable displayFunction : int;
   mutable displayMode : int;
   mutable displayControl : int;

--- a/src/stdlib/liquidCrystal.mli
+++ b/src/stdlib/liquidCrystal.mli
@@ -12,19 +12,25 @@ open Avr
 type ('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i) lcd
 
 (** Initialise a LCD in 4-bit mode : [create_4bitmode rs enable d0 d1 d2 d3] *)
-val create4bitmode : ('a register, 'b register, 'c register, no analog_pin) pin ->
-  ('d register, 'e register, 'f register, no analog_pin) pin ->
-  ('g register, 'h register, 'i register, no analog_pin) pin -> ('g register, 'h register, 'i register, no analog_pin) pin ->
-  ('g register, 'h register, 'i register, no analog_pin) pin -> ('g register, 'h register, 'i register, no analog_pin) pin ->
+val create4bitmode : ('a register, 'b analog_pin, 'c pwm_pin) pin ->
+  ('d register, 'e analog_pin, 'f pwm_pin) pin ->
+  ('g register, 'h analog_pin, 'i pwm_pin) pin ->
+  ('g register, 'h analog_pin, 'i pwm_pin) pin ->
+  ('g register, 'h analog_pin, 'i pwm_pin) pin ->
+  ('g register, 'h analog_pin, 'i pwm_pin) pin ->
   ('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i) lcd
 
 (** Initialise a LCD in 8-bit mode : [create_8bitmode rs enable d0 d1 d2 d3 d4 d5 d6 d7] *)
-val create8bitmode :  ('a register, 'b register, 'c register, no analog_pin) pin ->
-  ('d register, 'e register, 'f register, no analog_pin) pin ->
-  ('g register, 'h register, 'i register, no analog_pin) pin -> ('g register, 'h register, 'i register, no analog_pin) pin ->
-  ('g register, 'h register, 'i register, no analog_pin) pin -> ('g register, 'h register, 'i register, no analog_pin) pin ->
-  ('g register, 'h register, 'i register, no analog_pin) pin -> ('g register, 'h register, 'i register, no analog_pin) pin ->
-  ('g register, 'h register, 'i register, no analog_pin) pin -> ('g register, 'h register, 'i register, no analog_pin) pin ->
+val create8bitmode :  ('a register, 'b analog_pin, 'c pwm_pin) pin ->
+  ('d register, 'e analog_pin, 'f pwm_pin) pin ->
+  ('g register, 'h analog_pin, 'i pwm_pin) pin ->
+  ('g register, 'h analog_pin, 'i pwm_pin) pin ->
+  ('g register, 'h analog_pin, 'i pwm_pin) pin ->
+  ('g register, 'h analog_pin, 'i pwm_pin) pin ->
+  ('g register, 'h analog_pin, 'i pwm_pin) pin ->
+  ('g register, 'h analog_pin, 'i pwm_pin) pin ->
+  ('g register, 'h analog_pin, 'i pwm_pin) pin ->
+  ('g register, 'h analog_pin, 'i pwm_pin) pin ->
   ('a, 'b, 'c, 'd, 'e, 'f, 'g, 'h, 'i) lcd
 
 (** Start the LCD display with c columns and l lines : [lcdBegin lcd c l]. Was named [begin] in the C library, but is renamed because begin is a keyword in OCaml *)


### PR DESCRIPTION
As we discussed earlier, I'm thinking it would be a good idea to simplify the `pin` GADT types, by regrouping the first three parameters indicating the relevant register. That's what I've done in this PR.
I've also added one more parameter indicating if the `pin` is capable of PWM output, similar to the one indicating if it is capable of analog input.
Any thoughts on this ?